### PR TITLE
PR: Change project file extension to .gwt from .what

### DIFF
--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -324,7 +324,7 @@ class WHATPref(object):
     def __init__(self, parent=None):  # =======================================
 
         self.projectfile = os.path.join(
-            '..', 'Projects', 'Example', 'Example.what')
+            '..', 'Projects', 'Example', 'Example.gwt')
         self.language = 'English'
         self.fontsize_general = '14px'
         self.fontsize_console = '12px'

--- a/gwhat/projet/manager_projet.py
+++ b/gwhat/projet/manager_projet.py
@@ -93,7 +93,7 @@ class ProjetManager(QWidget):
     def select_project(self):
         directory = os.path.abspath(os.path.join('..', 'Projects'))
         filename, _ = QFileDialog.getOpenFileName(
-            self, 'Open Project', directory, '*.what')
+            self, 'Open Project', directory, '*.gwt ; *.what')
 
         if filename:
             self.projectfile = filename
@@ -329,7 +329,7 @@ class NewProject(QDialog):
 
         # ---- project.what ----
 
-        fname = os.path.join(dirname, '%s.what' % name)
+        fname = os.path.join(dirname, '%s.gwt' % name)
 
         projet = ProjetReader(fname)
         projet.name = self.name.text()
@@ -342,7 +342,7 @@ class NewProject(QDialog):
 
         del projet
 
-        print('Creating file %s.what' % name)
+        print('Creating file %s.gwt' % name)
         print('---------------')
 
         self.close()

--- a/gwhat/tests/test_projet.py
+++ b/gwhat/tests/test_projet.py
@@ -41,7 +41,7 @@ def test_create_new_projet(projet_manager_bot, mocker):
     manager.show()
 
     projetpath = os.path.join(
-            os.getcwd(), data_input['name'], data_input['name']+'.what')
+            os.getcwd(), data_input['name'], data_input['name']+'.gwt')
 
     # Delete project folder and its content if it already exist.
     if os.path.exists(os.path.join(os.getcwd(), data_input['name'])):
@@ -78,12 +78,12 @@ def test_load_projet(projet_manager_bot, mocker):
     manager.show_newproject_dialog()
 
     projetpath = os.path.join(
-            os.getcwd(), data_input['name'], data_input['name']+'.what')
+            os.getcwd(), data_input['name'], data_input['name']+'.gwt')
 
     # Mock the file dialog window so that we can specify programmatically
     # the path of the project.
     mocker.patch.object(QFileDialog, 'getOpenFileName',
-                        return_value=(projetpath, '*.what'))
+                        return_value=(projetpath, '*.gwt'))
 
     # Select and load the project.
     manager.select_project()
@@ -100,5 +100,5 @@ def test_load_projet(projet_manager_bot, mocker):
 
 
 if __name__ == "__main__":
-    pytest.main([os.path.basename(__file__)])
-    # pytest.main()
+    # pytest.main([os.path.basename(__file__)])
+    pytest.main()


### PR DESCRIPTION
Fixes #94

- Default extension for project file is now `.gwt` to be consistent with the docs and the new application name.
-  Compatibility with `.what` files was kept. In fact, any extension can be used. The format of the file remains the same. This only changes things for the project file explorer and for the tests.