### PR TITLE
PR: Fix water_level_measurements file management

### DIFF
--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -464,34 +464,6 @@ class HydroprintGUI(myqt.DialogWindow):
     def workdir(self):
         return self.dmngr.workdir
 
-    # ========================================================= Utilities =====
-
-    def check_files(self):
-
-        # water lvl manual measurements :
-
-        fname = os.path.join(self.workdir, 'waterlvl_manual_measurements.csv')
-        if not os.path.exists(fname):
-            msg = ('No "waterlvl_manual_measurements.xls" file found. '
-                   'A new one has been created.')
-            print(msg)
-
-            fcontent = [['Well_ID', 'Time (days)', 'Obs. (mbgs)']]
-            save_content_to_csv(fname, fcontent)
-
-        # graph_layout.lst :
-
-        filename = os.path.join(self.workdir, 'graph_layout.lst')
-        if not os.path.exists(filename):
-            msg = ('No "graph_layout.lst" file found. ' +
-                   'A new one has been created.')
-            print(msg)
-
-            fcontent = db.FileHeaders().graph_layout
-            save_content_to_csv(filename, fcontent)
-
-    # =========================================================================
-
     def zoom_in(self):
         self.hydrograph_scrollarea.zoomIn()
 

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -508,7 +508,8 @@ class HydroprintGUI(myqt.DialogWindow):
 
         # Load Manual Measures :
 
-        fname = os.path.join(self.workdir, 'waterlvl_manual_measurements.xls')
+        fname = os.path.join(self.workdir, "Water Levels",
+                             'waterlvl_manual_measurements')
         tmeas, wlmeas = load_waterlvl_measures(fname, wldset['Well'])
         wldset.set_wlmeas(tmeas, wlmeas)
 

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -47,7 +47,7 @@ import gwhat.mplFigViewer3 as mplFigViewer
 from gwhat.meteo.weather_viewer import WeatherAvgGraph
 from gwhat.colors2 import ColorsReader, ColorsSetupWin
 
-from gwhat.common import IconDB, StyleDB, QToolButtonNormal, QToolButtonSmall
+from gwhat.common import IconDB, QToolButtonNormal, QToolButtonSmall
 import gwhat.common.widgets as myqt
 import gwhat.common.database as db
 from gwhat.common.utils import save_content_to_csv

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -23,7 +23,6 @@ from __future__ import division, unicode_literals
 
 # ---- Standard library imports
 
-import csv
 import sys
 import os
 
@@ -49,8 +48,6 @@ from gwhat.colors2 import ColorsReader, ColorsSetupWin
 
 from gwhat.common import IconDB, QToolButtonNormal, QToolButtonSmall
 import gwhat.common.widgets as myqt
-import gwhat.common.database as db
-from gwhat.common.utils import save_content_to_csv
 from gwhat.projet.reader_waterlvl import load_waterlvl_measures
 
 
@@ -87,8 +84,6 @@ class HydroprintGUI(myqt.DialogWindow):
         # Generate UI:
 
         self.__initUI__()
-
-    # =========================================================================
 
     def __initUI__(self):
 
@@ -1157,15 +1152,13 @@ if __name__ == '__main__':
     ft.setPointSize(11)
     app.setFont(ft)
 
-    pf = ('C:/Users/jsgosselin/OneDrive/Research/'
-          'PostDoc - MDDELCC/Outils/BRF MontEst/'
-          'BRF MontEst.what')
+    pf = ("C:/Users/jsgosselin/GWHAT/gwhat/tests/"
+          "@ new-prô'jèt!/@ new-prô'jèt!.gwt")
     pr = ProjetReader(pf)
     dm = DataManager()
+    dm.set_projet(pr)
 
     Hydroprint = HydroprintGUI(dm)
     Hydroprint.show()
-
-    dm.set_projet(pr)
 
     sys.exit(app.exec_())

--- a/gwhat/projet/manager_projet.py
+++ b/gwhat/projet/manager_projet.py
@@ -39,6 +39,7 @@ from PyQt5.QtWidgets import (QWidget, QLabel, QDesktopWidget, QPushButton,
 from gwhat.projet.reader_projet import ProjetReader
 from gwhat.common import IconDB, QToolButtonSmall
 from gwhat.projet.manager_data import DataManager
+from gwhat.projet.reader_waterlvl import init_waterlvl_measures
 import gwhat.common.widgets as myqt
 from gwhat import __version__
 
@@ -110,6 +111,8 @@ class ProjetManager(QWidget):
             QMessageBox.warning(self, 'Warning', msg, btn)
             return False
         else:
+            wldir = os.path.join(projet.dirname, "Water Levels")
+            init_waterlvl_measures(wldir)
             self.project_display.setText(projet.name)
             self.project_display.adjustSize()
             self.currentProjetChanged.emit(projet)

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -48,6 +48,10 @@ class ProjetReader(object):
     def filename(self):
         return self.db.filename
 
+    @property
+    def dirname(self):
+        return os.path.dirname(self.filename)
+
     # =========================================================================
 
     def load_projet(self, filename):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -24,6 +24,9 @@ import numpy as np
 import xlrd
 import csv
 
+# ---- Imports: local
+from gwhat.common.utils import save_content_to_csv
+
 
 def load_excel_datafile(fname):
     print('Loading waterlvl time-series from Excel file...')
@@ -155,12 +158,22 @@ def load_waterlvl_measures(filename, well):
     resource file for the specified well.
     """
     print('Loading manual water level measures for well %s...' % well, end=" ")
+    time_mes, wl_mes = np.array([]), np.array([])
+    # Determine the extension of the file.
     root, ext = os.path.splitext(filename)
-    if not os.path.exists(filename):
+    exts = [ext] if ext in ['.csv, .xls, .xlsx'] else ['.csv, .xls, .xlsx']
+    for ext in exts:
+        filename = root+ext
+        if os.path.exists(root+ext):
+            break
+    else:
+        # The file does not exists, so we generate an empty file with
+        # a header.
         print("none")
         init_waterlvl_measures(os.path.dirname(root))
-        return np.array([]), np.array([])
+        return time_mes, wl_mes
 
+    # Open and read the file.
     if ext == '.csv':
         with open(filename, 'r') as f:
             reader = np.array(list(csv.reader(f, delimiter=',')))
@@ -178,8 +191,6 @@ def load_waterlvl_measures(filename, well):
             time = sheet.col_values(1, start_rowx=1, end_rowx=None)
             wl = sheet.col_values(2, start_rowx=1, end_rowx=None)
 
-            # Convert to Numpy :
-
             well_name = np.array(well_name).astype('str')
             time = np.array(time).astype('float')
             wl = np.array(wl).astype('float')
@@ -190,7 +201,8 @@ def load_waterlvl_measures(filename, well):
             wl_mes = wl[rowx]
             time_mes = time[rowx]
     print("done")
-    return np.array(time_mes), np.array(wl_mes)
+
+    return time_mes, wl_mes
 
 
 # =========================================================================

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -144,11 +144,23 @@ def make_waterlvl_continuous(t, wl):
     return t, wl
 
 
+# ---- Water level manual measurements
+
 def init_waterlvl_measures(dirname):
-    """Create an empty waterlvl_manual_measurements.csv file with headers."""
-    fname = os.path.join(dirname, 'waterlvl_manual_measurements.csv')
-    if not os.path.exists(fname):
+    """
+    Create an empty waterlvl_manual_measurements.csv file with headers
+    if it does not already exist.
+    """
+    for ext in ['.csv, .xls, .xlsx']:
+        fname = os.path.join(dirname, "waterlvl_manual_measurements"+ext)
+        if os.path.exists(fname):
+            return
+    else:
+        fname = os.path.join(dirname, 'waterlvl_manual_measurements.csv')
         fcontent = [['Well_ID', 'Time (days)', 'Obs. (mbgs)']]
+
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
         save_content_to_csv(fname, fcontent)
 
 

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -27,6 +27,8 @@ import csv
 # ---- Imports: local
 from gwhat.common.utils import save_content_to_csv
 
+FILE_EXTS = ['.csv', '.xls', '.xlsx']
+
 
 def load_excel_datafile(fname):
     print('Loading waterlvl time-series from Excel file...')
@@ -151,7 +153,7 @@ def init_waterlvl_measures(dirname):
     Create an empty waterlvl_manual_measurements.csv file with headers
     if it does not already exist.
     """
-    for ext in ['.csv, .xls, .xlsx']:
+    for ext in FILE_EXTS:
         fname = os.path.join(dirname, "waterlvl_manual_measurements"+ext)
         if os.path.exists(fname):
             return
@@ -173,7 +175,7 @@ def load_waterlvl_measures(filename, well):
     time_mes, wl_mes = np.array([]), np.array([])
     # Determine the extension of the file.
     root, ext = os.path.splitext(filename)
-    exts = [ext] if ext in ['.csv, .xls, .xlsx'] else ['.csv, .xls, .xlsx']
+    exts = [ext] if ext in FILE_EXTS else FILE_EXTS
     for ext in exts:
         filename = root+ext
         if os.path.exists(root+ext):

--- a/gwhat/tests/pytest_test_order.txt
+++ b/gwhat/tests/pytest_test_order.txt
@@ -6,6 +6,7 @@
 6 - test_gapfill_weather_algorithm.py
 7 - test_manager_data.py
 8 - test_hydroprint.py
+9 - test_hydrocalc.py
 
 test_tabwidget.py
 test_read_waterlvl.py

--- a/gwhat/tests/pytest_test_order.txt
+++ b/gwhat/tests/pytest_test_order.txt
@@ -8,3 +8,4 @@
 8 - test_hydroprint.py
 
 test_tabwidget.py
+test_read_waterlvl.py

--- a/gwhat/tests/pytest_test_order.txt
+++ b/gwhat/tests/pytest_test_order.txt
@@ -5,5 +5,6 @@
 5 - test_gapfill_weather_gui.py
 6 - test_gapfill_weather_algorithm.py
 7 - test_manager_data.py
+8 - test_hydroprint.py
 
 test_tabwidget.py

--- a/gwhat/tests/test_hydrocalc.py
+++ b/gwhat/tests/test_hydrocalc.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2014-2017 GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (GroundWater Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+
+# Standard library imports
+import sys
+import os
+
+# Third party imports
+import pytest
+from PyQt5.QtCore import Qt
+
+# Local imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+from gwhat.HydroCalc2 import WLCalc
+from gwhat.projet.manager_data import DataManager
+from gwhat.projet.reader_projet import ProjetReader
+
+
+# Qt Test Fixtures
+# --------------------------------
+
+
+working_dir = os.path.join(os.getcwd(), "@ new-prô'jèt!")
+output_dir = os.path.join(working_dir, "Water Levels")
+
+
+@pytest.fixture
+def hydrocalc_bot(qtbot):
+    pf = os.path.join(working_dir, "@ new-prô'jèt!.gwt")
+    pr = ProjetReader(pf)
+
+    dm = DataManager()
+    dm.set_projet(pr)
+
+    hydrocalc = WLCalc(dm)
+    qtbot.addWidget(hydrocalc)
+
+    return hydrocalc, qtbot
+
+
+# Test WLCalc
+# -------------------------------
+
+
+@pytest.mark.run(order=9)
+def test_hydrocalc_init(hydrocalc_bot, mocker):
+    hydrocalc, qtbot = hydrocalc_bot
+    hydrocalc.show()
+    assert hydrocalc
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])
+    # pytest.main()

--- a/gwhat/tests/test_hydroprint.py
+++ b/gwhat/tests/test_hydroprint.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2014-2017 GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (GroundWater Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+
+# Standard library imports
+import sys
+import os
+
+# Third party imports
+import pytest
+from PyQt5.QtCore import Qt
+
+# Local imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+from gwhat.HydroPrint2 import HydroprintGUI
+from gwhat.projet.manager_data import DataManager
+from gwhat.projet.reader_projet import ProjetReader
+
+
+# Qt Test Fixtures
+# --------------------------------
+
+
+working_dir = os.path.join(os.getcwd(), "@ new-prô'jèt!")
+output_dir = os.path.join(working_dir, "Water Levels")
+
+
+@pytest.fixture
+def hydroprint_bot(qtbot):
+    pf = os.path.join(working_dir, "@ new-prô'jèt!.gwt")
+    pr = ProjetReader(pf)
+
+    dm = DataManager()
+    dm.set_projet(pr)
+
+    hydroprint = HydroprintGUI(dm)
+    qtbot.addWidget(hydroprint)
+
+    return hydroprint, qtbot
+
+
+# Test HydroprintGUI
+# -------------------------------
+
+
+@pytest.mark.run(order=8)
+def test_hydroprint_init(hydroprint_bot, mocker):
+    hydroprint, qtbot = hydroprint_bot
+    hydroprint.show()
+    assert hydroprint
+
+    # Assert that the water_level_measurement file was initialize correctly.
+    filename = os.path.join(output_dir, "waterlvl_manual_measurements.csv")
+    assert os.path.exists(filename)
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])
+    # pytest.main()

--- a/gwhat/tests/test_read_waterlvl.py
+++ b/gwhat/tests/test_read_waterlvl.py
@@ -19,7 +19,7 @@ import xlsxwriter
 # Local imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 from gwhat.common.utils import save_content_to_csv, delete_file
-from gwhat.projet.reader_waterlvl import (load_waterlvl_measures, 
+from gwhat.projet.reader_waterlvl import (load_waterlvl_measures,
                                           init_waterlvl_measures)
 
 WLMEAS = [['Well_ID', 'Time (days)', 'Obs. (mbgs)'],
@@ -38,14 +38,16 @@ WLMEAS = [['Well_ID', 'Time (days)', 'Obs. (mbgs)'],
 
 def test_init_waterlvl_measures():
     # Assert that the water_level_measurement file is initialized correctly.
-    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements.csv")
-    assert not os.path.exists(filename)
-    init_waterlvl_measures(os.getcwd())
-    assert os.path.exists(filename)
+    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements")
+    assert not os.path.exists(filename+'.csv')
+    time, wl = load_waterlvl_measures(filename, 'Test')
+    assert os.path.exists(filename+'.csv')
+    assert len(time) == 0 and isinstance(time, np.ndarray)
+    assert len(wl) == 0 and isinstance(wl, np.ndarray)
 
     # Assert that the format of the file is correct.
     expected_result = ['Well_ID', 'Time (days)', 'Obs. (mbgs)']
-    with open(filename, 'r') as f:
+    with open(filename+'.csv', 'r') as f:
         reader = list(csv.reader(f, delimiter=','))
     assert len(reader) == 1
     assert reader[0] == expected_result

--- a/gwhat/tests/test_read_waterlvl.py
+++ b/gwhat/tests/test_read_waterlvl.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2014-2017 GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (GroundWater Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+
+# Standard library imports
+import sys
+import os
+import csv
+
+# Third party imports
+import pytest
+import numpy as np
+import xlsxwriter
+
+# Local imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+from gwhat.common.utils import save_content_to_csv, delete_file
+from gwhat.projet.reader_waterlvl import (load_waterlvl_measures, 
+                                          init_waterlvl_measures)
+
+WLMEAS = [['Well_ID', 'Time (days)', 'Obs. (mbgs)'],
+          ['Test', 40623.54167, 1.43],
+          ['Test', 40842.54167, 1.6],
+          ['Test', 41065.54167, 1.57],
+          ['test', 41065.54167, 1.57],
+          ["é@#^'", 41240.8125, 3.75],
+          ['test2', 41402.34375, 3.56],
+          ]
+
+
+# Test water_level_measurements.*
+# -------------------------------
+
+
+def test_init_waterlvl_measures():
+    # Assert that the water_level_measurement file is initialized correctly.
+    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements.csv")
+    assert not os.path.exists(filename)
+    init_waterlvl_measures(os.getcwd())
+    assert os.path.exists(filename)
+
+    # Assert that the format of the file is correct.
+    expected_result = ['Well_ID', 'Time (days)', 'Obs. (mbgs)']
+    with open(filename, 'r') as f:
+        reader = list(csv.reader(f, delimiter=','))
+    assert len(reader) == 1
+    assert reader[0] == expected_result
+
+
+def test_load_waterlvl_measures_withcsv():
+    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements.csv")
+    save_content_to_csv(filename, WLMEAS)
+
+    # Test init_waterlvl_measures to be sure the file is not overriden.
+    init_waterlvl_measures(os.getcwd())
+
+    # Assert that it loads the right data.
+    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements")
+    time, wl = load_waterlvl_measures(filename, 'Dummy')
+    assert len(time) == 0 and isinstance(time, np.ndarray)
+    assert len(wl) == 0 and isinstance(wl, np.ndarray)
+
+    time, wl = load_waterlvl_measures(filename, 'Test')
+    assert np.all(time == np.array([40623.54167, 40842.54167, 41065.54167]))
+    assert np.all(wl == np.array([1.43, 1.6, 1.57]))
+
+    time, wl = load_waterlvl_measures(filename, "é@#^'")
+    assert np.all(time == np.array([41240.8125]))
+    assert np.all(wl == np.array([3.75]))
+
+
+def test_load_waterlvl_measures_withxls():
+    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements.csv")
+    delete_file(filename)
+    assert not os.path.exists(filename)
+
+    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements.xlsx")
+    with xlsxwriter.Workbook(filename) as wb:
+        ws = wb.add_worksheet()
+        for i, line in enumerate(WLMEAS):
+            ws.write_row(i, 0, line)
+
+    # Test init_waterlvl_measures to be sure the file is not overriden.
+    init_waterlvl_measures(os.getcwd())
+
+    # Assert that it loads the right data.
+    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements")
+    time, wl = load_waterlvl_measures(filename, 'Dummy')
+    assert len(time) == 0 and isinstance(time, np.ndarray)
+    assert len(wl) == 0 and isinstance(wl, np.ndarray)
+
+    time, wl = load_waterlvl_measures(filename, 'Test')
+    assert np.all(time == np.array([40623.54167, 40842.54167, 41065.54167]))
+    assert np.all(wl == np.array([1.43, 1.6, 1.57]))
+
+    time, wl = load_waterlvl_measures(filename, "é@#^'")
+    assert np.all(time == np.array([41240.8125]))
+    assert np.all(wl == np.array([3.75]))
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])
+    # pytest.main()

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,0 +1,1 @@
+xlsxwriter>=0.9.6


### PR DESCRIPTION
Fixes #10

The objective of this PR is to make the initialization, editing, and saving of `water_level_measurements` files more robust.

First of all, the default location for the `water_level_measurements` file has been changed from the project folder to the `Water Levels` sub-folder. Moreover, a `water_level_measurements.csv` file is now initialize every time a project is started if it does not exist. Before initializing, it also check that no file with the same name already exist in the `xls` or `xlsx` format.

When loading data from the `water_level_measurements`, it will do so either from the csv, xls, or xlsx file. The csv format will be preferred if there is more than one file with this name, but with different extension.

Finally, a basic test was added to test the initialization of the HydroPrintGUI class and to check that the `water_level_measurements.csv` was initialized correctly