### PR TITLE
PR: Update the "About GWHAT" window and reduce startup time.

### DIFF
--- a/gwhat/tests/test_tabwidget.py
+++ b/gwhat/tests/test_tabwidget.py
@@ -12,9 +12,9 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 # ---- Third parties imports
 
-import pytest                                                          # nopep8
-from PyQt5.QtCore import Qt                                            # nopep8
-from PyQt5.QtWidgets import QWidget                                    # nopep8
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QWidget
 
 # ---- Local imports
 
@@ -31,8 +31,7 @@ def tabwidget_bot(qtbot):
     tabwidget.addTab(QWidget(), 'Tab#1')
     tabwidget.addTab(QWidget(), 'Tab#2')
     tabwidget.addTab(QWidget(), 'Tab#3')
-
-    tabwidget.aboutwhat.setModal(False)
+    tabwidget._pytesting = True
 
     qtbot.addWidget(tabwidget)
 
@@ -43,12 +42,20 @@ def tabwidget_bot(qtbot):
 
 
 def test_tabwidget_and_about_window(tabwidget_bot):
+    """Test the showing and closing of the About GWHAT window."""
     tabwidget, qtbot = tabwidget_bot
     tabwidget.show()
 
+    assert tabwidget.about_win is None
+
+    # Show about window and assert it was created and showed correctly.
     qtbot.mouseClick(tabwidget.about_btn, Qt.LeftButton)
-    assert tabwidget.aboutwhat.isVisible()
-    tabwidget.aboutwhat.close()
+    assert tabwidget.about_win
+    assert tabwidget.about_win.isVisible()
+
+    # Close the about window and assert it was closed correctly.
+    qtbot.mouseClick(tabwidget.about_win.ok_btn, Qt.LeftButton)
+    assert not tabwidget.about_win.isVisible()
 
 
 def test_tabwidget_index_memory(tabwidget_bot):

--- a/gwhat/widgets/about.py
+++ b/gwhat/widgets/about.py
@@ -19,7 +19,7 @@ from PyQt5.QtWidgets import (QDialog, QTextBrowser, QPushButton, QGridLayout,
 
 # ---- Local imports
 
-from gwhat import __version__, __date__
+from gwhat import __version__, __date__, __project_url__
 from gwhat.common import icons
 from gwhat import __rootdir__
 
@@ -132,9 +132,7 @@ class AboutWhat(QDialog):
                   <br>
                   Licensed under the terms of the GNU General Public License Version 3
                   <br>
-                  <a href="https://github.com/jnsebgosselin/gwhat">
-                    https://github.com/jnsebgosselin/gwhat
-                  </a>
+                  <a href="%s">%s</a>
                   <br>
                   <br>
                   Created by Jean-S&eacute;bastien Gosselin
@@ -154,7 +152,8 @@ class AboutWhat(QDialog):
                   </a>
                   <br>
                 </p1>
-                """ % (version[5:].strip(), __date__)
+                """ % (version[5:].strip(), __date__,
+                       __project_url__, __project_url__)
 
         # ---- License
 

--- a/gwhat/widgets/about.py
+++ b/gwhat/widgets/about.py
@@ -28,7 +28,6 @@ class AboutWhat(QDialog):
 
     def __init__(self, parent=None):
         super(AboutWhat, self).__init__(parent)
-
         self.__initUI__()
 
     def __initUI__(self):
@@ -37,9 +36,10 @@ class AboutWhat(QDialog):
 
         self.setWindowTitle('About %s' % __version__)
         self.setWindowIcon(icons.get_icon('master'))
-        self.setMinimumHeight(700)
-        self.setModal(True)
-        self.setWindowFlags(Qt.Window | Qt.WindowCloseButtonHint)
+        self.setMinimumSize(800, 700)
+        self.setWindowFlags(Qt.Window |
+                            Qt.CustomizeWindowHint |
+                            Qt.WindowCloseButtonHint)
 
         # ---- AboutTextBox ----
 
@@ -57,8 +57,8 @@ class AboutWhat(QDialog):
 
         # ---- Ok btn ----
 
-        ok_btn = QPushButton('OK')
-        ok_btn.clicked.connect(self.close)
+        self.ok_btn = QPushButton('OK')
+        self.ok_btn.clicked.connect(self.close)
 
         # ---- Main Grid ----
 
@@ -66,7 +66,7 @@ class AboutWhat(QDialog):
         grid.setSpacing(10)
 
         grid.addWidget(self.AboutTextBox, 0, 1, 1, 2)
-        grid.addWidget(ok_btn, 1, 2)
+        grid.addWidget(self.ok_btn, 1, 2)
 
         grid.setColumnStretch(1, 500)
         grid.setContentsMargins(10, 10, 10, 10)
@@ -81,7 +81,6 @@ class AboutWhat(QDialog):
 
         width = 750
         version = __version__
-        date = __date__
 
         filename = os.path.join(
                 __rootdir__, 'ressources', 'WHAT_banner_750px.png')

--- a/gwhat/widgets/about.py
+++ b/gwhat/widgets/about.py
@@ -92,76 +92,98 @@ class AboutWhat(QDialog):
         elif platform.system() == 'Linux':
             fontfamily = "Ubuntu"
 
-        about_text = '''
-                     <style>
-                     p{font-size: 14px;
-                       font-family: "%s";
-                       margin-right:50px;
-                       margin-left:50px}
-                     p1{font-size: 16px;
-                        font-family: "%s";
-                        }
-                     p2{font-size: 16px;
-                        font-family: "%s";}
-                     </style>
-                     ''' % (fontfamily, fontfamily, fontfamily)
+        html = """
+               <html>
+               <head>
+               <style>
+               p {font-size: 16px;
+                  font-family: "%s";
+                  margin-right:50px;
+                  margin-left:50px;
+                  }
+               p1 {font-size: 16px;
+                   font-family: "%s";
+                   margin-right:50px;
+                   margin-left:50px;
+                   }
+               </style>
+               </head>
+               <body>
+               """ % (fontfamily, fontfamily)
 
-        about_text += '''
-                      <p align="center"> <br>
-                        <img src="%s" width="%d">
-                      </p>
-                      ''' % (filename, width)
+        # ---- Banner
 
-        # ---- Header ----
+        html += """
+                <p align="left">
+                  <br><img src="file:///%s" width="%d"><br>
+                </p>
+                """ % (filename, width)
 
-        about_text += '''
-                      <p1 align=center>
-                        <br><br>
-                        Version %s<br>
-                      </p1>
-                      <p2 align=center>
-                        Copyright 2014-2017 Jean-S&eacute;bastien Gosselin<br>
-                        jean-sebastien.gosselin@ete.inrs.ca
-                      <br>
-                      <br>
-                        Institut National de la Recherche Scientifique<br>
-                        Research Center Eau Terre Environnement, Quebec City,
-                        QC, Canada<br>
-                        <a href="http://www.ete.inrs.ca/">
-                          (http://www.ete.inrs.ca)
-                        </a>
-                        <br>
-                      </p2>
-                      ''' % (version[5:].strip())
+        # ---- Copyrights
 
-        # ---- License ----
+        html += """
+                <br>
+                <p1 align="right">
+                  GWHAT version %s released on %s<br>
+                  Copyright 2014-2017
+                  <a href="https://github.com/jnsebgosselin/gwhat/graphs/contributors">
+                    GWHAT Project Contributors
+                  </a>
+                  <br>
+                  Licensed under the terms of the GNU General Public License Version 3
+                  <br>
+                  <a href="https://github.com/jnsebgosselin/gwhat">
+                    https://github.com/jnsebgosselin/gwhat
+                  </a>
+                  <br>
+                  <br>
+                  Created by Jean-S&eacute;bastien Gosselin
+                  <br>
+                  <a href="mailto:jean-sebastien.gosselin@ete.inrs.ca">
+                    jean-sebastien.gosselin@ete.inrs.ca
+                  </a>
+                  <br>
+                  <br>
+                  Developped and maintained by Jean-S&eacute;bastien Gosselin
+                  <br>
+                  Institut National de la Recherche Scientifique<br>
+                  Research Center Eau-Terre-Environnement, Quebec City,
+                  QC, Canada<br>
+                  <a href="http://www.ete.inrs.ca/">
+                    http://www.ete.inrs.ca
+                  </a>
+                  <br>
+                </p1>
+                """ % (version[5:].strip(), __date__)
 
-        about_text += '''
-                      <p align = "justify">
-                        %s is free software: you can redistribute it and/or
-                        modify it under the terms
-                        of the GNU General Public License as published by the
-                        Free Software Foundation, either version 3 of the
-                        License, or (at your option) any later version.
-                      </p>
-                      <p align="justify">
-                        This program is distributed in the hope that it will be
-                        useful, but WITHOUT ANY WARRANTY; without even the
-                        implied warranty of MERCHANTABILITY or FITNESS FOR A
-                        PARTICULAR PURPOSE. See the GNU General Public
-                        License for more details.
-                      </p>
-                      <p align="justify">
-                        You should have received a copy of the GNU General
-                        Public License along with this program.  If not, see
-                        <a href="http://www.gnu.org/licenses">
-                          http://www.gnu.org/licenses
-                        </a>.
-                      </p>
-                      <p align="right">%s</p>
-                      ''' % (version, date)
+        # ---- License
 
-        self.AboutTextBox.setHtml(about_text)
+        html += """
+                <p align="justify">
+                  %s is free software: you can redistribute it and/or
+                  modify it under the terms
+                  of the GNU General Public License as published by the
+                  Free Software Foundation, either version 3 of the
+                  License, or (at your option) any later version.
+                </p>
+                <p align="justify">
+                  This program is distributed in the hope that it will be
+                  useful, but WITHOUT ANY WARRANTY; without even the
+                  implied warranty of MERCHANTABILITY or FITNESS FOR A
+                  PARTICULAR PURPOSE. See the GNU General Public
+                  License for more details.
+                </p>
+                <p align="justify">
+                  You should have received a copy of the GNU General
+                  Public License along with this program.  If not, see
+                  <a href="http://www.gnu.org/licenses">
+                    http://www.gnu.org/licenses
+                  </a>.
+                </p>
+                </body>
+                """ % version
+
+        self.AboutTextBox.setHtml(html)
 
     # =========================================================================
 

--- a/gwhat/widgets/tabwidget.py
+++ b/gwhat/widgets/tabwidget.py
@@ -27,29 +27,43 @@ from gwhat.common import icons
 class TabWidget(QTabWidget):
     def __init__(self, parent=None):
         super(TabWidget, self).__init__(parent=None)
+        self._pytesting = False
 
-        self.aboutwhat = AboutWhat(parent=parent)
+        self.about_win = None
 
         self.about_btn = QToolButtonBase(icons.get_icon('info'))
         self.about_btn.setIconSize(QSize(20, 20))
         self.about_btn.setFixedSize(32, 32)
         self.about_btn.setToolTip('About WHAT...')
         self.about_btn.setParent(self)
-        self.about_btn.clicked.connect(self.aboutwhat.show)
+        self.about_btn.clicked.connect(self._about_btn_isclicked)
 
         tab_bar = TabBar(self, parent)
         self.setTabBar(tab_bar)
-        tab_bar.sig_resized.connect(self.moveAboutButton)
-        tab_bar.sig_tab_layout_changed.connect(self.moveAboutButton)
+        tab_bar.sig_resized.connect(self.__move_about_btn)
+        tab_bar.sig_tab_layout_changed.connect(self.__move_about_btn)
+
+    def _about_btn_isclicked(self):
+        """
+        Create and show the About GWHAT window when the about button
+        is clicked.
+        """
+        if self.about_win is None:
+            self.about_win = AboutWhat(self)
+        if self._pytesting:
+            self.about_win.show()
+        else:
+            self.about_win.exec_()
 
     def resizeEvent(self, event):
+        """Qt method override."""
         super().resizeEvent(event)
-        self.moveAboutButton()
+        self.__move_about_btn()
 
-    def moveAboutButton(self):
+    def __move_about_btn(self):
         """
-        Move the buton to show the About dialog window to the right side of the
-        tab bar.
+        Move the buton to show the About dialog window to the right
+        side of the tab bar.
         """
         x = 0
         for i in range(self.count()):


### PR DESCRIPTION
The objective of this PR is to update the text in the `About GWHAT` window to reflect the changes that were made for the copyrights of the software.

Also, in this PR the creation of the `About GWHAT` window is delayed when it is actually required, instead of generating it on startup. The objective is to reduce the startup time of GWHAT as discussed in  Issue  #56.

![image](https://user-images.githubusercontent.com/10170372/33855139-0ce36eb0-de92-11e7-861c-51595b6604a4.png)
