### PR TITLE
PR: Reduce the duration of the AppVeyor tests and improve the performance of the gapfilling tool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ Projects/
 .spyproject/
 @ new-prô'jèt!/
 
+Colors.db
 kgs_brf.exe
 WHAT.pref
 BRFInput.txt

--- a/gwhat/meteo/gapfill_weather_algorithm2.py
+++ b/gwhat/meteo/gapfill_weather_algorithm2.py
@@ -443,7 +443,7 @@ class GapFillWeather(QObject):
 
             for row in row2fill:
 
-                sleep(0.000001)  # If no sleep, the UI becomes whacked
+                # sleep(0.000001)  # If no sleep, the UI becomes whacked
 
                 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 # This block of code is used only to stop the gap-filling

--- a/gwhat/meteo/gapfill_weather_algorithm2.py
+++ b/gwhat/meteo/gapfill_weather_algorithm2.py
@@ -12,7 +12,7 @@ from __future__ import division, unicode_literals
 
 import csv
 import os
-from time import strftime, sleep
+from time import strftime
 from copy import copy
 from time import clock
 from itertools import product
@@ -442,8 +442,6 @@ class GapFillWeather(QObject):
             # INNER LOOP: iterates over all the days with missing values.
 
             for row in row2fill:
-
-                # sleep(0.000001)  # If no sleep, the UI becomes whacked
 
                 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 # This block of code is used only to stop the gap-filling

--- a/gwhat/tests/test_gapfill_weather_algorithm.py
+++ b/gwhat/tests/test_gapfill_weather_algorithm.py
@@ -79,12 +79,12 @@ def test_fill_data(gapfill_weather_bot):
     gapfiller.fill_data()
 
     gapfiller.set_target_station(1)
-    gapfiller.regression_mode = 1
+    gapfiller.limitDist = -1
+    gapfiller.limitAlt = -1
     gapfiller.fill_data()
 
     gapfiller.set_target_station(2)
-    gapfiller.limitDist = -1
-    gapfiller.limitAlt = -1
+    gapfiller.regression_mode = 1
     gapfiller.fill_data()
 
     # Assert that all the ouput files were generated correctly.


### PR DESCRIPTION
The objective of this PR is to find out why tests are taking so long on AppVeyor and to fix the problem if possible.

The tests are taking more than 15 minutes on AppVeyor while they were taking less than 4 minutes on Travis. I suspect this has something to do with a `sleep` I've included in the gapfilling routine to prevent some glitch with the UI.

The test are passing after 3 min 23 sec on Travis.
The tests are now passing after 3 min 4 sec on AppVeyor.

This StackOverflow answer seems to explain pretty good what is probably happening here during the tests:
https://stackoverflow.com/a/25355498/4481445

When running the test on my machine:
Without the `sleep`, it takes around 17 seconds.
With the `sleep`, it takes around 125 seconds.

**So basically, this `sleep` call needs to be removed at all costs.** But, some testing are needed before I merge this into master.