### PR TITLE
PR: Add csv support for input water level datafiles and extend the header infos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,10 @@ docs/_build/
 # PyBuilder
 target/
 
+# ---- Tests output files
+
+water_level_datafile.*
+waterlvl_manual_measurements.*
 
 # ---- Personal Ignore
 

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -617,7 +617,7 @@ class NewWaterLvl(NewDataset):
         for i in range(5):
             QCoreApplication.processEvents()
 
-        self._dataset = wlrd.load_excel_datafile(filename)
+        self._dataset = wlrd.read_water_level_datafile(filename)
 
         # Update GUI :
 

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -316,6 +316,7 @@ class WLDataFrameHDF5(dict):
         super(WLDataFrameHDF5, self).__init__(*args, **kwargs)
         self.dset = dset
 
+        # Make older datasets compatible with newer format :
 
         if 'Well ID' not in list(self.dset.attrs.keys()):
             # Added in version 0.2.1 (see PR #124).

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -196,10 +196,12 @@ class ProjetReader(object):
 
             grp.attrs['filename'] = df['filename']
             grp.attrs['Well'] = df['Well']
+            grp.attrs['Well ID'] = df['Well ID']
             grp.attrs['Latitude'] = df['Latitude']
             grp.attrs['Longitude'] = df['Longitude']
             grp.attrs['Elevation'] = df['Elevation']
             grp.attrs['Municipality'] = df['Municipality']
+            grp.attrs['Province'] = df['Province']
 
             # ---- MRC ----
 
@@ -303,13 +305,26 @@ class ProjetReader(object):
 
 
 class WLDataFrameHDF5(dict):
-    # This is a wrapper around the h5py group that is used to store
-    # water level datasets. It mimick the structure of the DataFrame that
-    # is returned when loading water level dataset from an Excel file in
-    # reader_waterlvl module.
+    """
+    This is a wrapper around the h5py group that is used to store
+    water level datasets. It mimick the structure of the DataFrame that
+    is returned when loading water level dataset from an Excel file in
+    reader_waterlvl module.
+    """
+
     def __init__(self, dset, *args, **kwargs):
         super(WLDataFrameHDF5, self).__init__(*args, **kwargs)
         self.dset = dset
+
+
+        if 'Well ID' not in list(self.dset.attrs.keys()):
+            # Added in version 0.2.1 (see PR #124).
+            dset.attrs['Well ID'] = ""
+            self.dset.file.flush()
+        if 'Province' not in list(self.dset.attrs.keys()):
+            # Added in version 0.2.1 (see PR #124).
+            dset.attrs['Province'] = ""
+            self.dset.file.flush()
 
     def __getitem__(self, key):
         if key in list(self.dset.attrs.keys()):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -56,13 +56,16 @@ def read_water_level_datafile(filename):
     # ---- Read the Header
 
     for row, line in enumerate(data):
+        if len(line) == 0:
+            continue
+
         label = line[0].lower().replace(":", "").replace("=", "").strip()
         if label == 'well name':
             df['Well'] = str(line[1])
         elif label == 'well id':
             df['Well ID'] = str(line[1])
         elif label == 'province':
-            df['Well ID'] = str(line[1])
+            df['Province'] = str(line[1])
         elif label == 'latitude':
             try:
                 df['Latitude'] = float(line[1])

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -22,7 +22,7 @@ FILE_EXTS = ['.csv', '.xls', '.xlsx']
 # ---- Read and Load Water Level Datafiles
 
 def read_water_level_datafile(filename):
-    """Load the data from a water level datafile in csv or Excel format."""
+    """Load a water level dataset from a csv or Excel file."""
     root, ext = os.path.splitext(filename)
     if ext not in FILE_EXTS:
         print("ERROR: supported file format are: ", FILE_EXTS)

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -21,8 +21,8 @@ FILE_EXTS = ['.csv', '.xls', '.xlsx']
 
 # ---- Read and Load Water Level Datafiles
 
-def load_excel_datafile(filename):
-    """Load the data from a water level datafile in Excel format."""
+def read_water_level_datafile(filename):
+    """Load the data from a water level datafile in csv or Excel format."""
     root, ext = os.path.splitext(filename)
     if ext not in FILE_EXTS:
         print("ERROR: supported file format are: ", FILE_EXTS)
@@ -44,7 +44,7 @@ def load_excel_datafile(filename):
           'ET': np.array([])}
 
     if ext == '.csv':
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf8') as f:
             data = list(csv.reader(f, delimiter=','))
     elif ext in ['.xls', '.xlsx']:
         with xlrd.open_workbook(filename, on_demand=True) as wb:
@@ -257,4 +257,6 @@ def generate_HTML_table(name, lat, lon, alt, mun):
 # ---- if __name__ == "__main__"
 
 if __name__ == "__main__":
-    df = load_excel_datafile("PO01_15min.xlsx")
+    df = read_water_level_datafile("PO01_15min.xlsx")
+    df2 = read_water_level_datafile("PO01_15min.xls")
+    df3 = read_water_level_datafile("PO01_15min.csv")

--- a/gwhat/tests/test_read_waterlvl.py
+++ b/gwhat/tests/test_read_waterlvl.py
@@ -18,9 +18,67 @@ import xlsxwriter
 
 # Local imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
-from gwhat.common.utils import save_content_to_csv, delete_file
-from gwhat.projet.reader_waterlvl import (load_waterlvl_measures,
-                                          init_waterlvl_measures)
+from gwhat.common.utils import (save_content_to_excel, save_content_to_csv,
+                                delete_file)
+from gwhat.projet.reader_waterlvl import (
+        load_waterlvl_measures, init_waterlvl_measures,
+        read_water_level_datafile)
+
+
+# Test reading water level datafiles
+# ----------------------------------
+
+DATA = [['Well name = ', "êi!@':i*"],
+        ['well id : ', '1234ABC'],
+        ['Province', 'Qc'],
+        ['latitude   ', 45.36],
+        ['Longitude=', -72.4234665345],
+        ['Elevation:', 123],
+        [],
+        [],
+        ['Date', 'WL(mbgs)', 'BP(m)', 'ET'],
+        [41241.69792, 3.667377006, 10.33327435, 383.9680352],
+        [41241.70833, 3.665777025, 10.33127437, 387.7404819],
+        [41241.71875, 3.665277031, 10.33097437, 396.9950643]
+        ]
+save_content_to_csv("water_level_datafile.csv", DATA)
+save_content_to_excel("water_level_datafile.xls", DATA)
+save_content_to_excel("water_level_datafile.xlsx", DATA)
+
+
+def test_reading_waterlvl():
+    df1 = read_water_level_datafile("water_level_datafile.csv")
+    df2 = read_water_level_datafile("water_level_datafile.csv")
+    df3 = read_water_level_datafile("water_level_datafile.csv")
+
+    assert list(df1.keys()) == list(df2.keys())
+    assert list(df2.keys()) == list(df3.keys())
+
+    expected_results = {
+          'Well': "êi!@':i*",
+          'Well ID': '1234ABC',
+          'Province': 'Qc',
+          'Latitude': 45.36,
+          'Longitude': -72.4234665345,
+          'Elevation': 123,
+          'Municipality': '',
+          'Time': np.array([41241.69792, 41241.70833, 41241.71875]),
+          'WL': np.array([3.667377006, 3.665777025, 3.665277031]),
+          'BP': np.array([10.33327435, 10.33127437, 10.33097437]),
+          'ET': np.array([383.9680352, 387.7404819, 396.9950643])}
+
+    keys = ['Well', 'Well ID', 'Province', 'Latitude', 'Longitude',
+            'Elevation', 'Municipality']
+    for key in keys:
+        assert df1[key] == expected_results[key]
+
+
+# Test water_level_measurements.*
+# -------------------------------
+
+delete_file("waterlvl_manual_measurements.csv")
+delete_file("waterlvl_manual_measurements.xls")
+delete_file("waterlvl_manual_measurements.xlsx")
 
 WLMEAS = [['Well_ID', 'Time (days)', 'Obs. (mbgs)'],
           ['Test', 40623.54167, 1.43],
@@ -30,10 +88,6 @@ WLMEAS = [['Well_ID', 'Time (days)', 'Obs. (mbgs)'],
           ["é@#^'", 41240.8125, 3.75],
           ['test2', 41402.34375, 3.56],
           ]
-
-
-# Test water_level_measurements.*
-# -------------------------------
 
 
 def test_init_waterlvl_measures():

--- a/gwhat/tests/test_read_waterlvl.py
+++ b/gwhat/tests/test_read_waterlvl.py
@@ -48,8 +48,8 @@ save_content_to_excel("water_level_datafile.xlsx", DATA)
 
 def test_reading_waterlvl():
     df1 = read_water_level_datafile("water_level_datafile.csv")
-    df2 = read_water_level_datafile("water_level_datafile.csv")
-    df3 = read_water_level_datafile("water_level_datafile.csv")
+    df2 = read_water_level_datafile("water_level_datafile.xls")
+    df3 = read_water_level_datafile("water_level_datafile.xlsx")
 
     assert list(df1.keys()) == list(df2.keys())
     assert list(df2.keys()) == list(df3.keys())


### PR DESCRIPTION
This is a partial fix for Issue #105 

Writing the documentation about how data is managed in GWHAT is not easy because the format of the input and ouput datafiles is not uniform throughout the entire workflow. So, a lot of text have to be added to specify what is the format for each input and output file. Besides, this is confusing for a new user. 

The ultimate goal is to make the management of inputs and outputs in GWHAT as uniform as possible. The work done in PR #84 and PR #108 were steps in that direction.

The objective of **this** PR is to add support for the `csv` format for the input waterlevel datafiles, in addition to the `xls` and `xlsx` formats. 

Also, keys were added to the water level datasets to make it more inline with the weather datasets. These keys are `Well ID` and `Province`.

