### PR TITLE
PR: Fix wrong values are shown for proximity in the Weather Stations Browser after changing either lat or lon value.

### DIFF
--- a/gwhat/meteo/search_weather_data.py
+++ b/gwhat/meteo/search_weather_data.py
@@ -146,7 +146,7 @@ class WeatherStationBrowser(QWidget):
         self.lat_spinBox.setMinimum(0)
         self.lat_spinBox.setMaximum(180)
         self.lat_spinBox.setSuffix(u' °')
-        self.lat_spinBox.valueChanged.connect(self.search_filters_changed)
+        self.lat_spinBox.valueChanged.connect(self.proximity_grpbox_toggled)
 
         label_Lon = QLabel('Longitude :')
         label_Lon2 = QLabel('West')
@@ -158,7 +158,7 @@ class WeatherStationBrowser(QWidget):
         self.lon_spinBox.setMinimum(0)
         self.lon_spinBox.setMaximum(180)
         self.lon_spinBox.setSuffix(u' °')
-        self.lon_spinBox.valueChanged.connect(self.search_filters_changed)
+        self.lon_spinBox.valueChanged.connect(self.proximity_grpbox_toggled)
 
         self.radius_SpinBox = QComboBox()
         self.radius_SpinBox.addItems(['25 km', '50 km', '100 km', '200 km'])
@@ -413,6 +413,11 @@ class WeatherStationBrowser(QWidget):
         return stnlist
 
     def proximity_grpbox_toggled(self):
+        """
+        Set the values for the reference geo coordinates that are used in the
+        WeatherSationView to calculate the proximity values and forces a
+        refresh of the content of the table.
+        """
         if self.prox_grpbox.isChecked():
             self.station_table.set_geocoord((self.lat, -self.lon))
         else:
@@ -420,6 +425,10 @@ class WeatherStationBrowser(QWidget):
         self.search_filters_changed()
 
     def search_filters_changed(self):
+        """
+        Search for weather stations with the current filter values and forces
+        an update of the station table content.
+        """
         stnlist = self.stn_finder.get_stationlist(
                 prov=self.prov, prox=self.prox,
                 yrange=(self.year_min, self.year_max, self.nbr_of_years))

--- a/gwhat/meteo/weather_stationlist.py
+++ b/gwhat/meteo/weather_stationlist.py
@@ -202,7 +202,7 @@ class WeatherSationView(QTableView):
     def populate_table(self, stationlist):
         self.stationlist = stationlist
         N = len(stationlist)
-        M = len(WeatherSationModel.HEADER)
+        M = len(WeatherStationModel.HEADER)
         if N == 0:
             data = np.empty((0, M))
         else:
@@ -229,7 +229,7 @@ class WeatherSationView(QTableView):
                               ]).transpose()
 
         checked = self.chkbox_header.checkState() == Qt.Checked
-        self.setModel(WeatherSationModel(data, checked))
+        self.setModel(WeatherStationModel(data, checked))
         self.model().sort(self.horizontalHeader().sortIndicatorSection(),
                           self.horizontalHeader().sortIndicatorOrder())
 
@@ -277,14 +277,14 @@ class WeatherSationView(QTableView):
         stationlist.save_to_file(filename)
 
 
-class WeatherSationModel(QAbstractTableModel):
+class WeatherStationModel(QAbstractTableModel):
 
     HEADER = ('', 'Weather Stations', 'Proximity\n(km)', 'From \n Year',
               'To \n Year', 'Prov.', 'Climate ID', 'Station ID',
               'Lat.\n(dd)', 'Lon.\n(dd)', 'Elev.\n(m)')
 
     def __init__(self, data, checked=False):
-        super(WeatherSationModel, self).__init__()
+        super(WeatherStationModel, self).__init__()
         self._data = data
         self._checks = np.ones(len(data)).astype(int) * int(checked)
 

--- a/gwhat/meteo/weather_stationlist.py
+++ b/gwhat/meteo/weather_stationlist.py
@@ -256,6 +256,13 @@ class WeatherSationView(QTableView):
             stationlist.append(self.stationlist[int(index)])
         return stationlist
 
+    def get_prox_data(self):
+        """Returns the proximity value shown in the table."""
+        if self.geocoord:
+            return np.array(self.model()._data[:, 2]).astype(float)
+        else:
+            return None
+
     def get_stationlist(self):
         """Get and format the content of the QTableView."""
         indexes = self.model()._data[:, 0]

--- a/gwhat/tests/test_search_weather_data.py
+++ b/gwhat/tests/test_search_weather_data.py
@@ -26,6 +26,8 @@ def station_finder_bot(qtbot):
     station_browser.set_yearmin(1960)
     station_browser.set_yearmax(2015)
     station_browser.set_yearnbr(10)
+    station_browser.set_lat(45)
+    station_browser.set_lon(60)
 
     qtbot.addWidget(station_browser)
 
@@ -70,8 +72,8 @@ def test_search_weather_station(station_finder_bot, mocker):
 
     # Search for stations and assert that lat and lon are 0.
     station_browser.prox_grpbox.setChecked(True)
-    assert station_browser.lon_spinBox.value() == 0
-    assert station_browser.lat_spinBox.value() == 0
+    assert station_browser.lat_spinBox.value() == 45.0
+    assert station_browser.lon_spinBox.value() == 60.0
 
     # Changed the values of the lat and lon and assert that the proximity
     # values are shown correctly.

--- a/gwhat/tests/test_search_weather_data.py
+++ b/gwhat/tests/test_search_weather_data.py
@@ -9,6 +9,7 @@ import pytest
 import sys
 import os
 from PyQt5.QtCore import Qt
+import numpy as np
 
 # Local imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
@@ -22,8 +23,6 @@ from gwhat.meteo.search_weather_data import QFileDialog                # nopep8
 @pytest.fixture
 def station_finder_bot(qtbot):
     station_browser = WeatherStationBrowser()
-    station_browser.set_lat(45.40)
-    station_browser.set_lon(73.15)
     station_browser.set_yearmin(1960)
     station_browser.set_yearmax(2015)
     station_browser.set_yearnbr(10)
@@ -69,8 +68,19 @@ def test_search_weather_station(station_finder_bot, mocker):
     station_browser.show()
     assert station_browser
 
-    # Search for stations and assert the results.
+    # Search for stations and assert that lat and lon are 0.
     station_browser.prox_grpbox.setChecked(True)
+    assert station_browser.lon_spinBox.value() == 0
+    assert station_browser.lat_spinBox.value() == 0
+
+    # Changed the values of the lat and lon and assert that the proximity
+    # values are shown correctly.
+    station_browser.lon_spinBox.setValue(73.15)
+    station_browser.lat_spinBox.setValue(45.40)
+    prox_data = station_browser.station_table.get_prox_data()
+    assert np.max(prox_data) <= 25
+
+    # Assert that the search returns the expected results.
     results = station_browser.stationlist
     assert results == expected_results
 


### PR DESCRIPTION
Fixes #128

The geo coordinates used to calculate the proximity values were not updated in the `WeatherSationView` when the latitude and longitude were changed in the UI. It was updated only when the `Proximity filter` was checked or unchecked.

Also the tests were expanded to catch this error before fixing it with this PR.

![proximity_is_ok_now](https://user-images.githubusercontent.com/10170372/34141265-11d1971e-e44e-11e7-9a60-22ddbba35462.gif)
