### PR TITLE
PR: Refactoring MainWindow startup routine.

### DIFF
--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -105,9 +105,10 @@ class MainWindow(QMainWindow):
         # Generate the GUI :
 
         self.__initUI__()
+        self.showMaximized()
+
         # Load the last opened project :
 
-        splash.showMessage("Loading last opened project.")
         result = self.pmanager.load_project(self.projectfile)
         if result is False:
             self.tab_dwnld_data.setEnabled(False)
@@ -360,7 +361,6 @@ if __name__ == '__main__':
                         format='%(asctime)s - %(levelname)s:%(message)s')
     try:
         main = MainWindow()
-        main.showMaximized()
         splash.finish(main)
         sys.exit(app.exec_())
     except Exception as e:

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -74,10 +74,10 @@ from gwhat.common import icons
 freeze_support()
 
 
-class WHAT(QMainWindow):
+class MainWindow(QMainWindow):
 
     def __init__(self, parent=None):
-        super(WHAT, self).__init__(parent)
+        super(MainWindow, self).__init__(parent)
 
         self.setWindowTitle(__namever__)
         self.setWindowIcon(icons.get_icon('master'))
@@ -219,7 +219,7 @@ class WHAT(QMainWindow):
     # =========================================================================
 
     def show(self):
-        super(WHAT, self).show()
+        super(MainWindow, self).show()
         qr = self.frameGeometry()
         cp = QDesktopWidget().availableGeometry().center()
         qr.moveCenter(cp)
@@ -363,7 +363,7 @@ if __name__ == '__main__':
     logging.basicConfig(filename='WHAT.log', level=logging.DEBUG,
                         format='%(asctime)s - %(levelname)s:%(message)s')
     try:
-        main = WHAT()
+        main = MainWindow()
         main.showMaximized()
         splash.finish(main)
         sys.exit(app.exec_())

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -116,15 +116,6 @@ class MainWindow(QMainWindow):
             self.tab_hydrograph.setEnabled(False)
             self.tab_hydrocalc.setEnabled(False)
 
-            msgtxt = '''
-                     Unable to read the project file.<br><br>
-                     "%s" does not exist.<br><br> Please open an existing
-                     project or create a new one.
-                     ''' % self.projectfile
-
-            btn = QMessageBox.Ok
-            QMessageBox.warning(self, 'Warning', msgtxt, btn)
-
     def __initUI__(self):
 
         # ---- TAB WIDGET

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -105,6 +105,7 @@ class MainWindow(QMainWindow):
         # Generate the GUI :
 
         self.__initUI__()
+        splash.finish(self)
         self.showMaximized()
 
         # Load the last opened project :
@@ -352,7 +353,6 @@ if __name__ == '__main__':
                         format='%(asctime)s - %(levelname)s:%(message)s')
     try:
         main = MainWindow()
-        splash.finish(main)
         sys.exit(app.exec_())
     except Exception as e:
         logging.exception(str(e))

--- a/gwhat/projet/manager_projet.py
+++ b/gwhat/projet/manager_projet.py
@@ -126,7 +126,9 @@ class ProjetManager(QWidget):
             return True
 
     def close_projet(self):
-        self.__projet.close_projet()
+        """Closes the currently opened hdf5 project file."""
+        if self.__projet is not None:
+            self.__projet.close_projet()
 
     def show_newproject_dialog(self):
         self.new_projet_dialog.reset_UI()

--- a/gwhat/projet/manager_projet.py
+++ b/gwhat/projet/manager_projet.py
@@ -11,6 +11,7 @@ from __future__ import division, unicode_literals
 # ---- Standard library imports
 
 import os
+import os.path as osp
 from datetime import datetime
 
 # ---- Third party imports
@@ -89,14 +90,32 @@ class ProjetManager(QWidget):
             self.load_project(filename)
 
     def load_project(self, filename):
+        if not osp.exists(filename):
+            self.__projet = None
+            msg = """
+                  <p>
+                    <b>Failed to load the project.</b><br><br>
+                    The project file<br>%s<br>
+                    does not exist.<br><br>
+                    Please open an existing project or create a new one.
+                  </p>
+                """ % osp.abspath(filename)
+            QMessageBox.warning(self, 'Warning', msg, QMessageBox.Ok)
+            return False
+
         try:
             self.__projet = projet = ProjetReader(filename)
-        except:
+        except Exception:
             self.__projet = None
-            msg = ('Project loading failed. <i>%s</i> is not a valid ' +
-                   'WHAT project file.') % os.path.basename(filename)
-            btn = QMessageBox.Ok
-            QMessageBox.warning(self, 'Warning', msg, btn)
+            msg = """
+                  <p>
+                    <b>Failed to load the project.</b><br><br>
+                    The project file<br>%s<br>
+                    is not valid.<br><br>
+                    Please open a valid project or create a new one.
+                  </p>
+                """ % osp.abspath(filename)
+            QMessageBox.warning(self, 'Warning', msg,  QMessageBox.Ok)
             return False
         else:
             wldir = os.path.join(projet.dirname, "Water Levels")

--- a/gwhat/projet/manager_projet.py
+++ b/gwhat/projet/manager_projet.py
@@ -104,7 +104,6 @@ class ProjetManager(QWidget):
             self.project_display.setText(projet.name)
             self.project_display.adjustSize()
             self.currentProjetChanged.emit(projet)
-
             return True
 
     def close_projet(self):
@@ -113,9 +112,6 @@ class ProjetManager(QWidget):
     def show_newproject_dialog(self):
         self.new_projet_dialog.reset_UI()
         self.new_projet_dialog.show()
-
-
-# :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
 class NewProject(QDialog):

--- a/gwhat/tests/pytest_test_order.txt
+++ b/gwhat/tests/pytest_test_order.txt
@@ -8,6 +8,7 @@
  8 - test_hydroprint.py
  9 - test_hydrocalc.py
 10 - test_brf_mod.py
+11 - test_mainwindow.py
 
 test_tabwidget.py
 test_read_waterlvl.py

--- a/gwhat/tests/test_mainwindow.py
+++ b/gwhat/tests/test_mainwindow.py
@@ -45,6 +45,12 @@ def mainwindow_bot(qtbot):
 
 @pytest.mark.run(order=11)
 def test_mainwindow_init(qtbot, mocker):
+    """
+    Tests that the MainWindow opens correctly and throws an error message
+    since the project Example does not exist. Asserts that GWHAT throws an
+    error message correctly when the project file is not valide. Finally,
+    tests that a valid project is loaded correctly.
+    """
     # Since the project Example does not exist, we need to mock QMessageBox
     # to close the warning message that will appears on startup.
     mocker.patch.object(QMessageBox, 'warning', return_value=QMessageBox.Ok)
@@ -75,6 +81,10 @@ def test_mainwindow_init(qtbot, mocker):
 
 @pytest.mark.run(order=11)
 def test_restart_mainwindow(qtbot, mocker):
+    """
+    Tests that the last opened valid project in the last session is loaded
+    correctly from the config file.
+    """
     mainwindow = MainWindow()
     qtbot.addWidget(mainwindow)
 

--- a/gwhat/tests/test_mainwindow.py
+++ b/gwhat/tests/test_mainwindow.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2014-2018 GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+
+# ---- Imports: Standard Libraries
+
+import sys
+import os
+import os.path as osp
+
+# ---- Imports: Tird Party Imports
+
+import pytest
+from PyQt5.QtCore import Qt
+
+# ---- Imports: Local Imports
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+from gwhat.mainwindow import MainWindow
+from gwhat.projet.manager_projet import QMessageBox
+
+
+# Qt Test Fixtures
+# --------------------------------
+
+
+PROJETPATH = osp.join(os.getcwd(), "@ new-prô'jèt!", "@ new-prô'jèt!.gwt")
+WORKDIR = os.getcwd()
+
+
+@pytest.fixture
+def mainwindow_bot(qtbot):
+    mainwindow = MainWindow()
+    qtbot.addWidget(mainwindow)
+
+    return mainwindow, qtbot
+
+
+# Test MainWindow
+# -------------------------------
+
+@pytest.mark.run(order=11)
+def test_mainwindow_init(qtbot, mocker):
+    # Since the project Example does not exist, we need to mock QMessageBox
+    # to close the warning message that will appears on startup.
+    mocker.patch.object(QMessageBox, 'warning', return_value=QMessageBox.Ok)
+    default_project_path = osp.join('..', 'Projects', 'Example', 'Example.gwt')
+    if osp.exists(osp.join(WORKDIR, 'WHAT.pref')):
+        os.remove(osp.join(WORKDIR, 'WHAT.pref'))
+
+    # Start GWHAT.
+    mainwindow = MainWindow()
+    qtbot.addWidget(mainwindow)
+
+    assert mainwindow
+    assert mainwindow.whatPref.projectfile == default_project_path
+    assert mainwindow.pmanager.projet is None
+
+    # Load a project file that is not valid. For the puspose of this test, we
+    # will use water_level_datafile.xlsx.
+    mainwindow.pmanager.load_project(
+            osp.join(WORKDIR, 'water_level_datafile.xlsx'))
+    assert mainwindow.whatPref.projectfile == default_project_path
+    assert mainwindow.pmanager.projet is None
+
+    # Load the valid project file that was created in the previous tests.
+    mainwindow.pmanager.load_project(PROJETPATH)
+    assert mainwindow.pmanager.projet is not None
+    assert mainwindow.whatPref.projectfile == PROJETPATH
+
+
+@pytest.mark.run(order=11)
+def test_restart_mainwindow(qtbot, mocker):
+    mainwindow = MainWindow()
+    qtbot.addWidget(mainwindow)
+
+    assert osp.abspath(mainwindow.whatPref.projectfile) == PROJETPATH
+    assert mainwindow.pmanager.projet is not None
+    assert osp.abspath(mainwindow.pmanager.projet.filename) == PROJETPATH
+    assert osp.abspath(mainwindow.pmanager.projet.dirname) == osp.dirname(PROJETPATH)
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])
+#     pytest.main()

--- a/gwhat/tests/test_projet.py
+++ b/gwhat/tests/test_projet.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-"""
-Created on Fri Aug  4 01:50:50 2017
-@author: jsgosselin
-"""
+
+# Copyright © 2014-2018 GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
 
 import pytest
 
@@ -70,6 +72,8 @@ def test_create_new_projet(projet_manager_bot, mocker):
     assert manager.project_display.text() == data_input['name']
     assert os.path.exists(projetpath)
 
+    manager.close_projet()
+
 
 @pytest.mark.run(order=1)
 def test_load_projet(projet_manager_bot, mocker):
@@ -97,6 +101,8 @@ def test_load_projet(projet_manager_bot, mocker):
     assert manager.projet.author == data_input['name']
     assert manager.projet.lat == data_input['latitude']
     assert manager.projet.lon == data_input['longitude']
+
+    manager.close_projet()
 
 
 if __name__ == "__main__":

--- a/gwhat/widgets/splash.py
+++ b/gwhat/widgets/splash.py
@@ -29,9 +29,10 @@ SPLASH_IMG = os.path.join(__rootdir__, 'ressources', 'splash.png')
 
 class SplashScrn(QSplashScreen):
     def __init__(self):
-        super(SplashScrn, self).__init__(QPixmap(SPLASH_IMG),
-                                         Qt.WindowStaysOnTopHint)
+        super(SplashScrn, self).__init__(QPixmap(SPLASH_IMG))
         self.show()
+        self.activateWindow()
+        self.raise_()
 
     def showMessage(self, msg):
         """Override Qt method."""


### PR DESCRIPTION
Fixes #54 and another step toward improving the startup time of GWHAT (see #56 ).

The objective of this PR is to fix various issues with the startup of GWHAT. More specifically:
- [x] Show the MainWindow before loading the project so that the startup time seems to be shorter.
- [x] Prevent a crash when closing GWHAT and the project is None.
- [x] Remove the StayOnTop window flag of the splash screen. This makes the later annoying.
- [x] Prevent a double error message on startup when the project does not exist.
- [x] Add tests for the MainWindow.