### PR TITLE
PR: Added proper support for saving in the xls (Excel 97/2000/XP/2003) format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - pip install h5py
   - pip install xlsxwriter
   - pip install xlrd
+  - pip install xlwt
   - pip install pytest
   - pip install pytest-qt
   - pip install pytest-xvfb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
   - python -m pip install h5py
   - python -m pip install xlsxwriter
   - python -m pip install xlrd
+  - python -m pip install xlwt
   - python -m pip install pytest
   - python -m pip install pytest-qt
   - python -m pip install pytest-xvfb

--- a/gwhat/common/utils.py
+++ b/gwhat/common/utils.py
@@ -18,6 +18,7 @@ from shutil import rmtree
 
 import numpy as np
 import xlsxwriter
+import xlwt
 
 
 def calc_dist_from_coord(lat1, lon1, lat2, lon2):
@@ -52,11 +53,18 @@ def save_content_to_csv(fname, fcontent, mode='w', delimiter=',',
 def save_content_to_excel(fname, fcontent):
     """Save content in a xls or xlsx file."""
     root, ext = os.path.splitext(fname)
-    fname = fname+'.xlsx' if ext not in ['.xls', '.xlsx'] else fname
-    with xlsxwriter.Workbook(fname) as wb:
-        ws = wb.add_worksheet()
+    if ext == '.xls':
+        wb = xlwt.Workbook()
+        ws = wb.add_sheet('Normals')
         for i, row in enumerate(fcontent):
-            ws.write_row(i, 0, row)
+            for j, cell in enumerate(row):
+                ws.write(i, j, cell)
+        wb.save(root+'.xls')
+    else:
+        with xlsxwriter.Workbook(root+'.xlsx') as wb:
+            ws = wb.add_worksheet('Normals')
+            for i, row in enumerate(fcontent):
+                ws.write_row(i, 0, row)
 
 
 def delete_file(filename):

--- a/gwhat/common/utils.py
+++ b/gwhat/common/utils.py
@@ -39,6 +39,20 @@ def calc_dist_from_coord(lat1, lon1, lat2, lon2):
     return r * c
 
 
+def save_content_to_file(fname, fcontent):
+    """
+    Smart function that checks the extension and save the content in the
+    appropriate file format.
+    """
+    root, ext = os.path.splitext(fname)
+    if ext in ['.xlsx', '.xls']:
+        save_content_to_excel(fname, fcontent)
+    elif ext == '.tsv':
+        save_content_to_csv(fname, fcontent, delimiter='\t')
+    else:
+        save_content_to_csv(fname, fcontent)
+
+
 def save_content_to_csv(fname, fcontent, mode='w', delimiter=',',
                         encoding='utf8'):
     """

--- a/gwhat/meteo/weather_stationlist.py
+++ b/gwhat/meteo/weather_stationlist.py
@@ -32,8 +32,7 @@ from PyQt5.QtWidgets import (QApplication, QTableView, QCheckBox, QStyle,
 
 # ---- Imports: local
 
-from gwhat.common.utils import (calc_dist_from_coord, save_content_to_csv,
-                                save_content_to_excel)
+from gwhat.common.utils import (calc_dist_from_coord, save_content_to_file)
 
 
 class WeatherSationList(list):
@@ -107,11 +106,7 @@ class WeatherSationList(list):
     def save_to_file(self, filename):
         """Save the content of the station list to file."""
         if filename:
-            root, ext = os.path.splitext(filename)
-            if ext in ['.xlsx', '.xls']:
-                save_content_to_excel(filename, self.get_file_content())
-            else:
-                save_content_to_csv(filename, self.get_file_content())
+            save_content_to_file(filename, self.get_file_content())
             print('Station list saved successfully in %s' % filename)
 
     def format_list_in_html(self):

--- a/gwhat/meteo/weather_viewer.py
+++ b/gwhat/meteo/weather_viewer.py
@@ -12,6 +12,7 @@ from __future__ import division, unicode_literals
 
 import sys
 import os
+import os.path as osp
 import csv
 from time import strftime
 
@@ -249,29 +250,18 @@ class WeatherAvgGraph(DialogWindow):
         dialog = QFileDialog()
         filename, ftype = dialog.getSaveFileName(
                 self, 'Save normals', ddir, '*.xlsx;;*.xls;;*.csv')
+        if filename:
+            self.save_fig_dir = osp.dirname(filename)
 
-        hheader = ['', 'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL',
-                   'AUG', 'SEP', 'OCT', 'NOV', 'DEC', 'YEAR']
+            hheader = ['', 'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL',
+                       'AUG', 'SEP', 'OCT', 'NOV', 'DEC', 'YEAR']
 
-        vrbs = ['Tmin', 'Tavg', 'Tmax', 'Rain', 'Snow', 'Ptot', 'PET']
+            vrbs = ['Tmin', 'Tavg', 'Tmax', 'Rain', 'Snow', 'Ptot', 'PET']
 
-        lbls = ['Daily Tmin (\u00B0C)', 'Daily Tavg (\u00B0C)',
-                'Daily Tmax (\u00B0C)', 'Rain (mm)', 'Snow (mm)',
-                'Total Precip. (mm)', 'ETP (mm)']
+            lbls = ['Daily Tmin (\u00B0C)', 'Daily Tavg (\u00B0C)',
+                    'Daily Tmax (\u00B0C)', 'Rain (mm)', 'Snow (mm)',
+                    'Total Precip. (mm)', 'ETP (mm)']
 
-        if ftype in ['*.xlsx', '*.xls']:
-            wb = xlsxwriter.Workbook(filename)
-            ws = wb.add_worksheet()
-
-            ws.write_row(0, 0, hheader)
-            for i, (vrb, lbl) in enumerate(zip(vrbs, lbls)):
-                ws.write(i+1, 0, lbl)
-                ws.write_row(i+1, 1, self.wxdset['normals'][vrb])
-                if vrb in ['Tmin', 'Tavg', 'Tmax']:
-                    ws.write(i+1, 13, np.mean(self.wxdset['normals'][vrb]))
-                else:
-                    ws.write(i+1, 13, np.sum(self.wxdset['normals'][vrb]))
-        elif ftype == '*.csv':
             fcontent = [hheader]
             for i, (vrb, lbl) in enumerate(zip(vrbs, lbls)):
                 fcontent.append([lbl])
@@ -280,10 +270,7 @@ class WeatherAvgGraph(DialogWindow):
                     fcontent[-1].append(np.mean(self.wxdset['normals'][vrb]))
                 else:
                     fcontent[-1].append(np.sum(self.wxdset['normals'][vrb]))
-
-            with open(filename, 'w', encoding='utf8')as f:
-                writer = csv.writer(f, delimiter=',', lineterminator='\n')
-                writer.writerows(fcontent)
+            save_content_to_file(filename, fcontent)
 
     # ================================================= Export Time Series ====
 
@@ -307,6 +294,7 @@ class WeatherAvgGraph(DialogWindow):
                 self, 'Export %s' % time_frame, ddir, '*.xlsx;;*.xls;;*.csv')
 
         if filename:
+            self.save_fig_dir = osp.dirname(filename)
             self.export_series_tofile(filename, time_frame)
 
     def export_series_tofile(self, filename, time_frame):

--- a/gwhat/meteo/weather_viewer.py
+++ b/gwhat/meteo/weather_viewer.py
@@ -309,8 +309,6 @@ class WeatherAvgGraph(DialogWindow):
         if filename:
             self.export_series_tofile(filename, time_frame)
 
-    # ---------------------------------------------------------------------
-
     def export_series_tofile(self, filename, time_frame):
         if time_frame == 'daily':
             vrbs = ['Year', 'Month', 'Day']
@@ -353,17 +351,16 @@ class WeatherAvgGraph(DialogWindow):
                     ['Created on', strftime("%d/%m/%Y")],
                     ['', '']
                     ]
+        fcontent.append(lbls)
 
         N = len(self.wxdset[time_frame]['Year'])
         M = len(vrbs)
-        data = np.zeros((N+1, M)).astype('str')
-        data[0, :] = lbls
+        data = np.zeros((N, M))
         for j, vrb in enumerate(vrbs):
-            data[1:, j] = self.wxdset[time_frame][vrb]
+            data[:, j] = self.wxdset[time_frame][vrb]
         fcontent.extend(data.tolist())
 
         save_content_to_file(filename, fcontent)
-
         QApplication.restoreOverrideCursor()
 
 


### PR DESCRIPTION
Currently, when saving anything using the `xls` file extension in GWHAT, the file is in reality saved in the `xlsx` format, but with an `xls` extension. This causes Words to throw an error when opening the file :

![image](https://user-images.githubusercontent.com/10170372/34843054-659ff292-f6db-11e7-8a7f-70cd36b0af43.png)

- This PR implements a new algorithm to save in the xls format using the [xlwt](https://pypi.python.org/pypi/xlwt) library instead of using [xlsxwriter](http://xlsxwriter.readthedocs.io/). 

- In addition, a new utility function that detects the file extension and save in the appropriate format was developed. This allowed to simplify and unify the code for saving content to file significantly.

- Finally, an additional bug was fixed that resulted in the date to be saved as text in Excel.