### PR TITLE
PR: Add more options to setup the x and y axis of the BRF graph.

### DIFF
--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -708,7 +708,7 @@ class BRFOptionsPanel(QWidget):
         self._xlim['max'] = QSpinBox()
         self._xlim['max'].setValue(1)
         self._xlim['max'].setSingleStep(1)
-        self._xlim['max'].setRange(0, 9999)
+        self._xlim['max'].setRange(1, 9999)
         self._xlim['max'].setEnabled(True)
         self._xlim['max'].valueChanged.connect(self._graphconf_changed)
         self._xlim['auto'] = QCheckBox('')

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -865,8 +865,10 @@ class BRFOptionsPanel(QWidget):
 if __name__ == "__main__":
     import gwhat.projet.reader_projet as prd
     import sys
-    projet = prd.ProjetReader("C:/Users/jsgosselin/GWHAT/gwhat/"
-                              "tests/@ new-prô'jèt!/@ new-prô'jèt!.gwt")
+    projet = prd.ProjetReader("C:/Users/jsgosselin/GWHAT/Projects/Example/"
+                              "Example.gwt")
+    # projet = prd.ProjetReader("C:/Users/jsgosselin/GWHAT/gwhat/"
+                              # "tests/@ new-prô'jèt!/@ new-prô'jèt!.gwt")
     wldset = projet.get_wldset(projet.wldsets[0])
 
     app = QApplication(sys.argv)
@@ -879,6 +881,8 @@ if __name__ == "__main__":
     brfwin = BRFManager(None)
     brfwin.show()
     brfwin.set_wldset(wldset)
+    brfwin.viewer.show()
+    brfwin.viewer.toggle_graphpannel()
 
     sys.exit(app.exec_())
 

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -466,80 +466,6 @@ class BRFViewer(QWidget):
         self.tbar.setColumnStretch(row, 100)
         self.tbar.setContentsMargins(10, 0, 10, 10)  # (l, t, r, b)
 
-        # ---- Graph Options Panel
-
-        self._errorbar = QCheckBox('Show error bars')
-        self._errorbar.setCheckState(Qt.Checked)
-        self._errorbar.stateChanged.connect(self.plot_brf)
-
-        self._drawline = QCheckBox('Draw line')
-        self._drawline.setCheckState(Qt.Unchecked)
-        self._drawline.stateChanged.connect(self.plot_brf)
-
-        self._markersize = {}
-        self._markersize['label'] = QLabel('Marker size :')
-        self._markersize['widget'] = QSpinBox()
-        self._markersize['widget'].setValue(5)
-        self._markersize['widget'].setRange(0, 25)
-        self._markersize['widget'].valueChanged.connect(self.plot_brf)
-
-        # Axis limits
-
-        axlayout = QGridLayout()
-        axlayout.addWidget(QLabel('y-axis limits:'), 0, 0, 1, 2)
-        axlayout.addWidget(QLabel('   Minimum :'), 1, 0)
-        axlayout.addWidget(QLabel('   Maximum :'), 2, 0)
-        axlayout.addWidget(QLabel('   Auto :'), 3, 0)
-
-        self._ylim = {}
-        self._ylim['min'] = QDoubleSpinBox()
-        self._ylim['min'].setValue(0)
-        self._ylim['min'].setDecimals(1)
-        self._ylim['min'].setSingleStep(0.1)
-        self._ylim['min'].setRange(-10, 10)
-        self._ylim['min'].setEnabled(True)
-        self._ylim['min'].valueChanged.connect(self.plot_brf)
-
-        self._ylim['max'] = QDoubleSpinBox()
-        self._ylim['max'].setValue(1)
-        self._ylim['max'].setDecimals(1)
-        self._ylim['max'].setSingleStep(0.1)
-        self._ylim['max'].setRange(-10, 10)
-        self._ylim['max'].setEnabled(True)
-        self._ylim['max'].valueChanged.connect(self.plot_brf)
-
-        self._ylim['auto'] = QCheckBox('')
-        self._ylim['auto'].setCheckState(Qt.Unchecked)
-        self._ylim['auto'].stateChanged.connect(self.xlimModeChanged)
-
-        axlayout.addWidget(self._ylim['min'], 1, 1)
-        axlayout.addWidget(self._ylim['max'], 2, 1)
-        axlayout.addWidget(self._ylim['auto'], 3, 1)
-
-        axlayout.setColumnStretch(3, 100)
-        axlayout.setContentsMargins(0, 0, 0, 0)  # (left, top, right, bottom)
-
-        # Layout
-
-        self.graph_pan = myqt.QFrameLayout()
-        self.graph_pan.setContentsMargins(10, 0, 10, 0)  # (l, t, r, b)
-        self.graph_pan.setVisible(False)
-
-        row = 0
-        self.graph_pan.addWidget(self._errorbar, row, 1, 1, 2)
-        row += 1
-        self.graph_pan.addWidget(self._drawline, row, 1, 1, 2)
-        row += 1
-        self.graph_pan.addWidget(self._markersize['label'], row, 1)
-        self.graph_pan.addWidget(self._markersize['widget'], row, 2)
-        row += 1
-        self.graph_pan.addWidget(myqt.HSep(), row, 1, 1, 2)
-        row += 1
-        self.graph_pan.addLayout(axlayout, row, 1, 1, 2)
-        row += 1
-        self.graph_pan.setRowMinimumHeight(row, 15)
-        self.graph_pan.setRowStretch(row, 100)
-
         # ---- Graph Canvas
 
         self.fig_frame = QFrame()
@@ -554,83 +480,39 @@ class BRFViewer(QWidget):
         fflay.addWidget(self.tbar, 1, 0)
         fflay.addWidget(self.brf_canvas, 0, 0)
 
+        # ---- Graph Options Panel
+
+        self.graph_opt_panel = BRFOptionsPanel()
+        self.graph_opt_panel.sig_graphconf_changed.connect(self.plot_brf)
+
         # ---- Main Layout
 
         ml = QGridLayout(self)
 
         ml.addWidget(self.fig_frame, 0, 2)
-        ml.addWidget(self.graph_pan, 0, 3)
+        ml.addWidget(self.graph_opt_panel, 0, 3)
 
         ml.setColumnStretch(1, 100)
 
-    # =========================================================================
-
-    def set_wldset(self, wldset):
-        self.wldset = wldset
-        if wldset is None:
-            self.setEnabled(False)
-        else:
-            self.setEnabled(True)
-            self.update_brfnavigate_state()
-
-    # ---- Graph Panel Properties
-
-    @property
-    def ymin(self):
-        if self._ylim['auto'].checkState() == Qt.Checked:
-            return None
-        else:
-            return self._ylim['min'].value()
-
-    @property
-    def ymax(self):
-        if self._ylim['auto'].checkState() == Qt.Checked:
-            return None
-        else:
-            return self._ylim['max'].value()
-
-    @property
-    def show_ebar(self):
-        return self._errorbar.checkState() == Qt.Checked
-
-    @property
-    def draw_line(self):
-        return self._drawline.checkState() == Qt.Checked
-
-    @property
-    def markersize(self):
-        return self._markersize['widget'].value()
-
-    # ---- Graph Panel Handlers
+    # ---- Toolbar Handlers
 
     def toggle_graphpannel(self):
-        if self.graph_pan.isVisible() is True:
+        if self.graph_opt_panel.isVisible() is True:
             # Hide the panel.
-            self.graph_pan.setVisible(False)
+            self.graph_opt_panel.setVisible(False)
             self.btn_setp.setAutoRaise(True)
             self.btn_setp.setToolTip('Show graph layout parameters...')
 
-            w = self.size().width() - self.graph_pan.size().width()
+            w = self.size().width() - self.graph_opt_panel.size().width()
             self.setFixedWidth(w)
         else:
             # Show the panel.
-            self.graph_pan.setVisible(True)
+            self.graph_opt_panel.setVisible(True)
             self.btn_setp.setAutoRaise(False)
             self.btn_setp.setToolTip('Hide graph layout parameters...')
 
-            w = self.size().width() + self.graph_pan.size().width()
+            w = self.size().width() + self.graph_opt_panel.size().width()
             self.setFixedWidth(w)
-
-    def xlimModeChanged(self, state):
-        """
-        Handles when the Auto checkbox state change for the
-        limits of the y-axis.
-        """
-        self._ylim['min'].setEnabled(state != 2)
-        self._ylim['max'].setEnabled(state != 2)
-        self.plot_brf()
-
-    # ---- Toolbar Handlers
 
     def navigate_brf(self):
         if self.sender() == self.btn_prev:
@@ -691,6 +573,16 @@ class BRFViewer(QWidget):
         """Saves the current BRF figure to fname."""
         self.brf_canvas.figure.savefig(fname)
 
+    # ---- Others
+
+    def set_wldset(self, wldset):
+        self.wldset = wldset
+        if wldset is None:
+            self.setEnabled(False)
+        else:
+            self.setEnabled(True)
+            self.update_brfnavigate_state()
+
     def plot_brf(self):
         self.brf_canvas.figure.set_language(self.cbb_language.currentText())
         if self.wldset.brf_count() == 0:
@@ -700,13 +592,18 @@ class BRFViewer(QWidget):
             lag, A, err, date_start, date_end = self.wldset.get_brf(name)
             well = self.wldset['Well']
 
-            if self.show_ebar is False:
+            if self.graph_opt_panel.show_ebar is False:
                 err = []
-            msize = self.markersize
-            draw_line = self.draw_line
+            msize = self.graph_opt_panel.markersize
+            draw_line = self.graph_opt_panel.draw_line
 
-            ymin = self.ymin
-            ymax = self.ymax
+            ymin = self.graph_opt_panel.ymin
+            ymax = self.graph_opt_panel.ymax
+
+            xmin = self.graph_opt_panel.xmin
+            xmax = self.graph_opt_panel.xmax
+
+            time_units = self.graph_opt_panel.time_units
 
             date0 = '%02d/%02d/%04d' % (date_start[2],
                                         date_start[1],
@@ -716,8 +613,9 @@ class BRFViewer(QWidget):
                                         date_end[1],
                                         date_end[0])
 
-            self.brf_canvas.figure.plot_BRF(lag, A, err, date0, date1, well,
-                                            msize, draw_line, [ymin, ymax])
+            self.brf_canvas.figure.plot_BRF(
+                    lag, A, err, date0, date1, well, msize, draw_line,
+                    [ymin, ymax], [xmin, xmax], time_units)
         self.brf_canvas.draw()
 
     def show(self):
@@ -743,7 +641,226 @@ class BRFViewer(QWidget):
             self.setWindowState(Qt.WindowNoState)
 
 
-# ---- if __name__ == "__main__":
+class BRFOptionsPanel(QWidget):
+    """A Panel where the options to plot the graph are displayed."""
+
+    sig_graphconf_changed = QSignal()
+
+    def __init__(self, parent=None):
+        super(BRFOptionsPanel, self).__init__(parent)
+        self.__initGUI__()
+        self.setVisible(False)
+
+    def __initGUI__(self):
+        # ---- Line and Markers Style Widgets
+
+        self._errorbar = QCheckBox('Show error bars')
+        self._errorbar.setCheckState(Qt.Checked)
+        self._errorbar.stateChanged.connect(self._graphconf_changed)
+
+        self._drawline = QCheckBox('Draw line')
+        self._drawline.setCheckState(Qt.Unchecked)
+        self._drawline.stateChanged.connect(self._graphconf_changed)
+
+        self._markersize = {}
+        self._markersize['label'] = QLabel('Marker size :')
+        self._markersize['widget'] = QSpinBox()
+        self._markersize['widget'].setValue(5)
+        self._markersize['widget'].setRange(0, 25)
+        self._markersize['widget'].valueChanged.connect(
+                self._graphconf_changed)
+
+        # ---- Y-Axis Options Widgets
+
+        self._ylim = {}
+        self._ylim['min'] = QDoubleSpinBox()
+        self._ylim['min'].setValue(0)
+        self._ylim['min'].setDecimals(1)
+        self._ylim['min'].setSingleStep(0.1)
+        self._ylim['min'].setRange(-10, 10)
+        self._ylim['min'].setEnabled(True)
+        self._ylim['min'].valueChanged.connect(self._graphconf_changed)
+        self._ylim['max'] = QDoubleSpinBox()
+        self._ylim['max'].setValue(1)
+        self._ylim['max'].setDecimals(1)
+        self._ylim['max'].setSingleStep(0.1)
+        self._ylim['max'].setRange(-10, 10)
+        self._ylim['max'].setEnabled(True)
+        self._ylim['max'].valueChanged.connect(self._graphconf_changed)
+        self._ylim['auto'] = QCheckBox('')
+        self._ylim['auto'].setCheckState(Qt.Checked)
+        self._ylim['auto'].stateChanged.connect(self.axis_autocheck_changed)
+
+        # ---- X-Axis Options Widgets
+
+        self._xlim = {}
+        self._xlim['units'] = QComboBox()
+        self._xlim['units'].addItems(['Hours', 'Days'])
+        self._xlim['units'].setCurrentIndex(1)
+        self._xlim['units'].currentIndexChanged.connect(
+                self.time_units_changed)
+        self._xlim['min'] = QSpinBox()
+        self._xlim['min'].setValue(0)
+        self._xlim['min'].setSingleStep(1)
+        self._xlim['min'].setRange(0, 9999)
+        self._xlim['min'].setEnabled(True)
+        self._xlim['min'].valueChanged.connect(self._graphconf_changed)
+        self._xlim['max'] = QSpinBox()
+        self._xlim['max'].setValue(1)
+        self._xlim['max'].setSingleStep(1)
+        self._xlim['max'].setRange(0, 9999)
+        self._xlim['max'].setEnabled(True)
+        self._xlim['max'].valueChanged.connect(self._graphconf_changed)
+        self._xlim['auto'] = QCheckBox('')
+        self._xlim['auto'].setCheckState(Qt.Checked)
+        self._xlim['auto'].stateChanged.connect(self.axis_autocheck_changed)
+
+        self.axis_autocheck_changed()
+
+        # ---- Axis Options Layout
+
+        axlayout = QGridLayout()
+
+        row = 0
+        axlayout.addWidget(QLabel('y-axis limits:'), 0, 0, 1, 2)
+        row += 1
+        axlayout.addWidget(QLabel('   Minimum :'), row, 0)
+        axlayout.addWidget(self._ylim['min'], row, 1)
+        row += 1
+        axlayout.addWidget(QLabel('   Maximum :'), row, 0)
+        axlayout.addWidget(self._ylim['max'], row, 1)
+        row += 1
+        axlayout.addWidget(QLabel('   Auto :'), row, 0)
+        axlayout.addWidget(self._ylim['auto'], row, 1)
+        row += 1
+        axlayout.setRowMinimumHeight(row, 15)
+        row += 1
+        axlayout.addWidget(QLabel('x-axis limits:'), row, 0, 1, 2)
+        row += 1
+        axlayout.addWidget(QLabel('   Time units :'), row, 0)
+        axlayout.addWidget(self._xlim['units'], row, 1)
+        row += 1
+        axlayout.addWidget(QLabel('   Minimum :'), row, 0)
+        axlayout.addWidget(self._xlim['min'], row, 1)
+        row += 1
+        axlayout.addWidget(QLabel('   Maximum :'), row, 0)
+        axlayout.addWidget(self._xlim['max'], row, 1)
+        row += 1
+        axlayout.addWidget(QLabel('   Auto :'), row, 0)
+        axlayout.addWidget(self._xlim['auto'], row, 1)
+
+        axlayout.setColumnStretch(3, 100)
+        axlayout.setContentsMargins(0, 0, 0, 0)  # (left, top, right, bottom)
+
+        # ---- Graph Panel Layout
+
+        layout = QGridLayout(self)
+        layout.setContentsMargins(10, 0, 10, 0)  # (l, t, r, b)
+
+        row = 0
+        layout.addWidget(self._errorbar, row, 1, 1, 2)
+        row += 1
+        layout.addWidget(self._drawline, row, 1, 1, 2)
+        row += 1
+        layout.addWidget(self._markersize['label'], row, 1)
+        layout.addWidget(self._markersize['widget'], row, 2)
+        row += 1
+        layout.addWidget(myqt.HSep(), row, 1, 1, 2)
+        row += 1
+        layout.addLayout(axlayout, row, 1, 1, 2)
+        row += 1
+        layout.setRowMinimumHeight(row, 15)
+        layout.setRowStretch(row, 100)
+
+    def _graphconf_changed(self):
+        """
+        Emits a signal to indicate that the graph configuration has changed.
+        """
+        self.sig_graphconf_changed.emit()
+
+    # ---- Graph Panel Properties
+
+    @property
+    def time_units(self):
+        if self._xlim['auto'].checkState() == Qt.Checked:
+            return 'auto'
+        else:
+            return self._xlim['units'].currentText().lower()
+
+    @property
+    def xmin(self):
+        if self._xlim['auto'].checkState() == Qt.Checked:
+            return None
+        if self.time_units == 'hours':
+            return self._xlim['min'].value()/24
+        else:
+            return self._xlim['min'].value()
+
+    @property
+    def xmax(self):
+        if self._xlim['auto'].checkState() == Qt.Checked:
+            return None
+        if self.time_units == 'hours':
+            return self._xlim['max'].value()/24
+        else:
+            return self._xlim['max'].value()
+
+    @property
+    def ymin(self):
+        if self._ylim['auto'].checkState() == Qt.Checked:
+            return None
+        else:
+            return self._ylim['min'].value()
+
+    @property
+    def ymax(self):
+        if self._ylim['auto'].checkState() == Qt.Checked:
+            return None
+        else:
+            return self._ylim['max'].value()
+
+    @property
+    def show_ebar(self):
+        return self._errorbar.checkState() == Qt.Checked
+
+    @property
+    def draw_line(self):
+        return self._drawline.checkState() == Qt.Checked
+
+    @property
+    def markersize(self):
+        return self._markersize['widget'].value()
+
+    # ---- Handlers
+
+    def time_units_changed(self):
+        """ Handles when the time_units combobox selection changes."""
+        for xlim in [self._xlim['min'], self._xlim['max']]:
+            xlim.blockSignals(True)
+            if self._xlim['units'].currentText() == 'Hours':
+                xlim.setValue(xlim.value()*24)
+            elif self._xlim['units'].currentText() == 'Days':
+                xlim.setValue(xlim.value()/24)
+            xlim.blockSignals(False)
+
+        self._graphconf_changed()
+
+    def axis_autocheck_changed(self):
+        """
+        Handles when the Auto checkbox state change for the
+        limits of the y-axis or the x-axis.
+        """
+        self._ylim['min'].setEnabled(not self._ylim['auto'].isChecked())
+        self._ylim['max'].setEnabled(not self._ylim['auto'].isChecked())
+
+        self._xlim['units'].setEnabled(not self._xlim['auto'].isChecked())
+        self._xlim['min'].setEnabled(not self._xlim['auto'].isChecked())
+        self._xlim['max'].setEnabled(not self._xlim['auto'].isChecked())
+
+        self._graphconf_changed()
+
+
+# %% if __name__ == "__main__"
 
 if __name__ == "__main__":
     import gwhat.projet.reader_projet as prd

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -909,10 +909,10 @@ class BRFOptionsPanel(QWidget):
 if __name__ == "__main__":
     import gwhat.projet.reader_projet as prd
     import sys
-    projet = prd.ProjetReader("C:/Users/jsgosselin/GWHAT/Projects/Example/"
-                              "Example.gwt")
-    # projet = prd.ProjetReader("C:/Users/jsgosselin/GWHAT/gwhat/"
-                              # "tests/@ new-prô'jèt!/@ new-prô'jèt!.gwt")
+    # projet = prd.ProjetReader("C:/Users/jsgosselin/GWHAT/Projects/Example/"
+    #                            "Example.gwt")
+    projet = prd.ProjetReader("C:/Users/jsgosselin/GWHAT/gwhat/"
+                              "tests/@ new-prô'jèt!/@ new-prô'jèt!.gwt")
     wldset = projet.get_wldset(projet.wldsets[0])
 
     app = QApplication(sys.argv)

--- a/gwhat/brf_mod/kgs_plot.py
+++ b/gwhat/brf_mod/kgs_plot.py
@@ -106,7 +106,7 @@ class BRFFigure(mpl.figure.Figure):
 
     def plot_BRF(self, lag, A, err, date0, date1, well, msize=0,
                  draw_line=True, ylim=[None, None], xlim=[None, None],
-                 time_units='auto'):
+                 time_units='auto', xscl=None, yscl=None):
         ax = self.axes[0]
         ax.set_visible(True)
 
@@ -156,6 +156,26 @@ class BRFFigure(mpl.figure.Figure):
         ymax += 10**-12
         xmax += 10**-12
 
+        # ---- Xticks Setup
+
+        if time_units == 'hours':
+            # We want the ticks to be a multiple of 24.
+            if xscl is None:
+                if np.floor(xmax) > 24*7:
+                    xscl = 24
+                elif np.floor(xmax) > 48:
+                    xscl = 12
+                elif np.floor(xmax) > 12:
+                    xscl = 4
+                else:
+                    xscl = 1
+            else:
+                xscl *= 24
+        elif time_units == 'days':
+            if xscl is None:
+                xscl = 1
+
+        ax.set_xticks(np.arange(xmin, xmax+xscl, xscl))
         ax.axis([xmin, xmax, ymin, ymax])
 
         # ---- Update the data

--- a/gwhat/brf_mod/kgs_plot.py
+++ b/gwhat/brf_mod/kgs_plot.py
@@ -183,8 +183,12 @@ class BRFFigure(mpl.figure.Figure):
         self.line.set_ydata(A)
         self.line.set_visible(draw_line)
 
-        self.markers.set_xdata(lag)
-        self.markers.set_ydata(A)
+        indexes = np.where((lag >= xmin) & (lag <= xmax) &
+                           (A >= ymin) & (A <= ymax)
+                           )[0]
+
+        self.markers.set_xdata(lag[indexes])
+        self.markers.set_ydata(A[indexes])
         self.markers.set_markersize(msize)
 
         self.errbar.remove()

--- a/gwhat/brf_mod/kgs_plot.py
+++ b/gwhat/brf_mod/kgs_plot.py
@@ -66,11 +66,6 @@ class BRFFigure(mpl.figure.Figure):
         ax.tick_params(axis='both', which='major', direction='out',
                        gridOn=True)
 
-        # ---- Axis Labels
-
-        ax.set_xlabel(self.fig_labels.lag, fontsize=14, labelpad=8)
-        ax.set_ylabel(self.fig_labels.A, fontsize=14)
-
         # ---- Artists Init
 
         self.line, = ax.plot([], [], ls='-', color='blue', linewidth=1.5,
@@ -105,30 +100,40 @@ class BRFFigure(mpl.figure.Figure):
         self.__figlang = lang
         self.__figlabels = FigureLabels(lang)
 
-        ax = self.axes[0]
-        ax.set_xlabel(self.fig_labels.lag, fontsize=14, labelpad=8)
-        ax.set_ylabel(self.fig_labels.A, fontsize=14)
-
     def empty_BRF(self):
         ax = self.axes[0]
         ax.set_visible(False)
 
     def plot_BRF(self, lag, A, err, date0, date1, well, msize=0,
-                 draw_line=True, ylim=[None, None]):
+                 draw_line=True, ylim=[None, None], xlim=[None, None],
+                 time_units='auto'):
         ax = self.axes[0]
         ax.set_visible(True)
 
-        lag_max = np.max(lag)
+        # ---- Xticks labels time_units
 
-        # ---- Ticks Setup
+        if time_units not in ['days', 'hours', 'auto']:
+                             ['days', 'hours', 'auto'])
+        if time_units == 'auto':
+            time_units = 'days' if np.max(lag) >= 2 else 'hours'
+        if time_units == 'hours':
+            lag = lag * 24
+            xlim[0] = None if xlim[0] is None else xlim[0]*24
+            xlim[1] = None if xlim[1] is None else xlim[1]*24
 
-        TCKPOS = np.arange(0, max(lag_max+1, 10), 1)
-        ax.set_xticks(TCKPOS)
+        # ---- Axis Labels
 
-        TCKPOS = np.arange(-10, 10, 0.2)
-        ax.set_yticks(TCKPOS)
+        if time_units == 'hours':
+            ax.set_xlabel(self.fig_labels.lag_hr, fontsize=14, labelpad=8)
+        else:
+            ax.set_xlabel(self.fig_labels.lag, fontsize=14, labelpad=8)
+
+        ax.set_ylabel(self.fig_labels.A, fontsize=14)
 
         # ---- Axis Limits
+
+        xmin = 0 if xlim[0] is None else xlim[0]
+        xmax = np.max(lag) if xlim[1] is None else xlim[1]
 
         if ylim[0] is None:
             if len(err) > 0:
@@ -148,8 +153,9 @@ class BRFFigure(mpl.figure.Figure):
 
         ymin += -10**-12
         ymax += 10**-12
+        xmax += 10**-12
 
-        ax.axis([0, lag_max, ymin, ymax])
+        ax.axis([xmin, xmax, ymin, ymax])
 
         # ---- Update the data
 

--- a/gwhat/brf_mod/kgs_plot.py
+++ b/gwhat/brf_mod/kgs_plot.py
@@ -113,6 +113,7 @@ class BRFFigure(mpl.figure.Figure):
         # ---- Xticks labels time_units
 
         if time_units not in ['days', 'hours', 'auto']:
+            raise ValueError("time_units value must be either :",
                              ['days', 'hours', 'auto'])
         if time_units == 'auto':
             time_units = 'days' if np.max(lag) >= 2 else 'hours'

--- a/gwhat/brf_mod/kgs_plot.py
+++ b/gwhat/brf_mod/kgs_plot.py
@@ -15,18 +15,20 @@ import matplotlib as mpl
 import numpy as np
 
 
-class FigureLabels():
+class FigureLabels(object):
     LANGUAGES = ['english', 'french']
 
     def __init__(self, language):
-        self.lag = 'Time Lag (days)'
-        self.A = 'Cumulative Response Function'
-        self.title = ('Well %s from %s to %s')
-
         if language.lower() == 'french':
-            self.lag = 'Lag temporel (h)'
+            self.lag = 'Lag temporel (jours)'
+            self.lag_hr = 'Lag temporel (heures)'
             self.A = 'Réponse barométrique cumulative'
             self.title = 'Puits %s du %s au %s'
+        else:
+            self.lag = 'Time Lag (days)'
+            self.lag_hr = 'Time Lag (hours)'
+            self.A = 'Cumulative Response Function'
+            self.title = ('Well %s from %s to %s')
 
 
 class BRFFigure(mpl.figure.Figure):

--- a/gwhat/brf_mod/kgs_plot.py
+++ b/gwhat/brf_mod/kgs_plot.py
@@ -152,11 +152,10 @@ class BRFFigure(mpl.figure.Figure):
         else:
             ymax = ylim[1]
 
-        ymin += -10**-12
-        ymax += 10**-12
-        xmax += 10**-12
+        # ---- Xticks ans Yticks Setup
 
-        # ---- Xticks Setup
+        yscl = 0.2 if yscl is None else yscl
+        ax.set_yticks(np.arange(ymin, ymax+yscl, yscl))
 
         if time_units == 'hours':
             # We want the ticks to be a multiple of 24.
@@ -174,9 +173,9 @@ class BRFFigure(mpl.figure.Figure):
         elif time_units == 'days':
             if xscl is None:
                 xscl = 1
-
         ax.set_xticks(np.arange(xmin, xmax+xscl, xscl))
-        ax.axis([xmin, xmax, ymin, ymax])
+
+        ax.axis([xmin, xmax+10**-12, ymin-10**-12, ymax+10**-12])
 
         # ---- Update the data
 

--- a/gwhat/tests/test_brf_mod.py
+++ b/gwhat/tests/test_brf_mod.py
@@ -129,6 +129,7 @@ def test_save_brf_figure(brf_manager_bot, mocker):
 def test_graph_panel(brf_manager_bot, mocker):
     brf_manager, qtbot = brf_manager_bot
     brf_manager.show()
+    graph_opt_panel = brf_manager.viewer.graph_opt_panel
 
     # Set the water level dataset.
     ppath = osp.join(os.getcwd(), "@ new-prô'jèt!", "@ new-prô'jèt!.gwt")
@@ -140,24 +141,56 @@ def test_graph_panel(brf_manager_bot, mocker):
     qtbot.waitExposed(brf_manager.viewer)
 
     # Toggle on the panel and assert it is shown correctly.
-    assert(brf_manager.viewer.graph_pan.isVisible() is False)
+    assert(graph_opt_panel.isVisible() is False)
     qtbot.mouseClick(brf_manager.viewer.btn_setp, Qt.LeftButton)
-    assert(brf_manager.viewer.graph_pan.isVisible())
+    assert(graph_opt_panel.isVisible())
 
-    # Assert the default values.
-    assert(brf_manager.viewer.ymin == 0)
-    assert(brf_manager.viewer.ymax == 1)
-    brf_manager.viewer._ylim['auto'].setChecked(True)
-    assert(brf_manager.viewer.ymin is None)
-    assert(brf_manager.viewer.ymax is None)
+    # Assert the default values for the y-axis :
 
-    assert brf_manager.viewer.show_ebar is True
-    assert brf_manager.viewer.draw_line is False
-    assert brf_manager.viewer.markersize == 5
+    assert(graph_opt_panel.ymin is None)
+    assert(graph_opt_panel.ymax is None)
+    assert(graph_opt_panel.yscale is None)
+
+    graph_opt_panel._ylim['auto'].setChecked(False)
+    assert(graph_opt_panel.ymin == 0)
+    assert(graph_opt_panel.ymax == 1)
+
+    # Assert the default values for the x-axis :
+
+    assert(graph_opt_panel.xmin is None)
+    assert(graph_opt_panel.xmax is None)
+    assert(graph_opt_panel.xscale is None)
+    assert(graph_opt_panel.time_units is 'auto')
+
+    graph_opt_panel._xlim['auto'].setChecked(False)
+    assert(graph_opt_panel.xmin == 0)
+    assert(graph_opt_panel._xlim['min'].value() == 0)
+    assert(graph_opt_panel.xmax == 1)
+    assert(graph_opt_panel._xlim['max'].value() == 1)
+    assert(graph_opt_panel.xscale == 1)
+    assert(graph_opt_panel._xlim['scale'].value() == 1)
+    assert(graph_opt_panel.time_units == 'days')
+
+    # Assert when the value of time_units change :
+
+    graph_opt_panel._xlim['units'].setCurrentIndex(0)
+    assert(graph_opt_panel.time_units == 'hours')
+    assert(graph_opt_panel.xmin == 0)
+    assert(graph_opt_panel._xlim['min'].value() == 0)
+    assert(graph_opt_panel.xmax == 1)
+    assert(graph_opt_panel._xlim['max'].value() == 24)
+    assert(graph_opt_panel.xscale == 1)
+    assert(graph_opt_panel._xlim['scale'].value() == 24)
+
+    # Assert the default values for the artists :
+
+    assert graph_opt_panel.show_ebar is True
+    assert graph_opt_panel.draw_line is False
+    assert graph_opt_panel.markersize == 5
 
     # Toggle off the panel and assert it is hidden correctly.
     qtbot.mouseClick(brf_manager.viewer.btn_setp, Qt.LeftButton)
-    assert(brf_manager.viewer.graph_pan.isVisible() is False)
+    assert(brf_manager.viewer.graph_opt_panel.isVisible() is False)
 
 
 @pytest.mark.run(order=9)


### PR DESCRIPTION
The goal of this PR is to fix a problem that appeared when plotting the BRF with a time lag that is less than a day. This resulted in a x-axis that had 0 tick and label.

The approach that was taken to solve this issue is to allow the user to select the time scale (hours or days) used to plot the BRF. To do so, a complete new section was added that allows the user to customize the x-axis, similarly to what was already available for the y-axis. Moreover, options were added to also set the scale of the x and y axis in the GUI.

![brf_viewer](https://user-images.githubusercontent.com/10170372/35532224-81e1cd56-0507-11e8-8b74-b56fde76233e.gif)





