### PR TITLE
PR: Prevent GWHAT from crashing when evaluating recharge and no behavioural model are found and show a warning.

### DIFF
--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -100,8 +100,6 @@ class RechgEvalWorker(QObject):
 
         # ---- Load Data ----
 
-        print('--------')
-
         self.wxdset = wxdset
 
         # Includes the estimation of ETP if not already present in file.
@@ -109,8 +107,6 @@ class RechgEvalWorker(QObject):
         self.ETP = self.wxdset['PET']
         self.PTOT = self.wxdset['Ptot']
         self.TAVG = self.wxdset['Tavg']
-
-        print('--------')
 
         self.wldset = wldset
 
@@ -137,8 +133,6 @@ class RechgEvalWorker(QObject):
         self.TIME = self.wxdset['Time'][ts:te+1]
         self.DATE = self.convert_time_to_date(self.YEAR, self.MONTH, DAY)
         self.PRECIP = self.wxdset['Ptot'][ts:te+1]
-
-    # =========================================================================
 
     def make_data_daily(self, t, h):
         argsort = np.argsort(t)
@@ -194,7 +188,7 @@ class RechgEvalWorker(QObject):
         print('Min Recharge = %0.1f mm/y' % min_rechg)
         print('Most Probable Recharge = %0.1f mm/y' % prob_rechg)
 
-    # =============================================================== GLUE ====
+    # ---- GLUE
 
     def calcul_GLUE(self):
         if self.glue_pardist_res == 'rough':

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -241,13 +241,15 @@ class RechgEvalWorker(QObject):
         tend = time.clock()
         print("GLUE computed in : ", tend-tstart)
 
-        print('-'*78)
-        print('range Sy = %0.3f to %0.3f' % (np.min(set_Sy), np.max(set_Sy)))
-        print('range RASmax = %d to %d' % (np.min(set_RASmax),
-                                           np.max(set_RASmax)))
-        print('range Cru = %0.3f to %0.3f' % (np.min(set_Cru),
-                                              np.max(set_Cru)))
-        print('-'*78)
+        if len(set_RMSE) > 0:
+            print('-'*78)
+            range_sy = (np.min(set_Sy), np.max(set_Sy))
+            print('range Sy = %0.3f to %0.3f' % range_sy)
+            range_rasmax = (np.min(set_RASmax), np.max(set_RASmax))
+            print('range RASmax = %d to %d' % range_rasmax)
+            range_cru = (np.min(set_Cru), np.max(set_Cru))
+            print('range Cru = %0.3f to %0.3f' % range_cru)
+            print('-'*78)
 
         self.glue_results = {}
         self.glue_results['RMSE'] = set_RMSE

--- a/gwhat/gwrecharge/gwrecharge_gui.py
+++ b/gwhat/gwrecharge/gwrecharge_gui.py
@@ -61,7 +61,7 @@ class RechgEvalWidget(QFrameLayout):
                 layout.setColumnStretch(0, 100)
                 self.setLayout(layout)
 
-        # ---------------------------------------------------------- Toolbar --
+        # ---- Toolbar
 
         toolbar_widget = QWidget()
 
@@ -74,7 +74,7 @@ class RechgEvalWidget(QFrameLayout):
 
         toolbar_widget.setLayout(toolbar_layout)
 
-        # ------------------------------------------------------- Parameters --
+        # ---- Parameters
 
         # Specific yield (Sy) :
 
@@ -127,7 +127,7 @@ class RechgEvalWidget(QFrameLayout):
                 super(QLabelCentered, self).__init__(text)
                 self.setAlignment(Qt.AlignCenter)
 
-        # ---- Parameters ----
+        # ---- Parameters
 
         params_group = QFrameLayout()
         params_group.setContentsMargins(10, 5, 10, 0)  # (L, T, R, B)
@@ -272,7 +272,7 @@ class RechgEvalWidget(QFrameLayout):
 
     def receive_glue_calcul(self, N):
         """
-        Handles the plotting of the results once ground-water recharge has
+        Handle the plotting of the results once ground-water recharge has
         been evaluated.
         """
         self.rechg_thread.quit()

--- a/gwhat/gwrecharge/gwrecharge_gui.py
+++ b/gwhat/gwrecharge/gwrecharge_gui.py
@@ -13,7 +13,8 @@ import time
 import matplotlib.pyplot as plt
 from PyQt5.QtCore import Qt, QThread
 from PyQt5.QtWidgets import (QWidget, QGridLayout, QPushButton, QProgressBar,
-                             QLabel, QSizePolicy, QScrollArea, QApplication)
+                             QLabel, QSizePolicy, QScrollArea, QApplication,
+                             QMessageBox)
 
 # ---- Imports: local
 
@@ -278,6 +279,14 @@ class RechgEvalWidget(QFrameLayout):
         self.progressbar.hide()
         if N == 0:
             print("The number of behavioural model produced is 0.")
+            msg = ("Recharge evaluation was not possible because all"
+                   " the models produced were deemed non-behavioural."
+                   "\n\n"
+                   "This usually happens when the range of values for"
+                   " Sy, RASmax, and Cro are too restrictive or when the"
+                   " Master Recession Curve (MRC) does not represent well the"
+                   " behaviour of the observed hydrograph.")
+            QMessageBox.warning(self, 'Warning', msg, QMessageBox.Ok)
         else:
             glue_data = self.rechg_worker.glue_results
             # self.rechg_worker.save_glue_to_npy("GLUE.npy")


### PR DESCRIPTION
Fixes #153 

The bug occurred only because of a print statement. A warning was also added to indicate to the user that the evaluation of recharge was not possible. The warning message reads as:

> Recharge evaluation was not possible because all the models produced were deemed non-behavioural.<br><br>This usually happens when the range of values for Sy, RASmax, and Cro are too restrictive or when the Master Recession Curve (MRC) does not represent well the behaviour of the observed hydrograph.


![image](https://user-images.githubusercontent.com/10170372/37117273-c2e385d6-221e-11e8-904e-6eda8d983ff0.png)