### PR TITLE
PR: Clip the observed water level dataset to the weather dataset to prevent GWHAT from crashing when evaluating groundwater recharge.

### DIFF
--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -155,14 +155,15 @@ class RechgEvalWorker(QObject):
         return td, hd
 
     @staticmethod
-    def convert_time_to_date(YEAR, MONTH, DAY):
-
-        DATE = [0] * len(YEAR)
-        for t in range(len(YEAR)):
-            DATE[t] = datetime.datetime(int(YEAR[t]), int(MONTH[t]),
-                                        int(DAY[t]), 0)
-
-        return DATE
+    def convert_time_to_date(years, months, days):
+        """
+        Produce datetime series from years, months, and days series.
+        """
+        dates = [0] * len(years)
+        for t in range(len(years)):
+            dates[t] = datetime.datetime(
+                    int(years[t]), int(months[t]), int(days[t]), 0)
+        return dates
 
     def calc_recharge(self, data=None):
         data = self.glue_results

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -152,7 +152,7 @@ class RechgEvalWorker(QObject):
             if len(indx) > 0:
                 hd[i] = h[indx[-1]]
 
-        return t1d, h1d
+        return td, hd
 
     @staticmethod
     def convert_time_to_date(YEAR, MONTH, DAY):

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -33,23 +33,15 @@ class RechgEvalWorker(QObject):
 
     def __init__(self):
         super(RechgEvalWorker, self).__init__()
-
         self.wxdset = None
         self.ETP, self.PTOT, self.TAVG = [], [], []
 
         self.wldset = None
         self.A, self.B = None, None
-
         self.twlvl = []
         self.WLVLobs = []
         self.NaNindx = []
-
-        self.YEAR = []
-        self.MONTH = []
-        self.TIME = []
-        self.PRECIP = []
-
-        self.DATE = []
+        self.wl_date = []
 
         self.TMELT = 0
         self.CM = 4
@@ -63,8 +55,6 @@ class RechgEvalWorker(QObject):
         self.glue_results = None
         self.fig = None
         self.glue_pardist_res = 'fine'
-
-    # =========================================================================
 
     @property
     def language(self):
@@ -127,12 +117,12 @@ class RechgEvalWorker(QObject):
         ts = self.ts = np.where(self.twlvl[0] == tweatr)[0][0]
         te = self.te = np.where(self.twlvl[-1] == tweatr)[0][0]
 
-        self.YEAR = self.wxdset['Year'][ts:te+1]
-        self.MONTH = self.wxdset['Month'][ts:te+1]
-        DAY = self.wxdset['Day'][ts:te+1]
-        self.TIME = self.wxdset['Time'][ts:te+1]
-        self.DATE = self.convert_time_to_date(self.YEAR, self.MONTH, DAY)
-        self.PRECIP = self.wxdset['Ptot'][ts:te+1]
+
+        years = self.wxdset['Year'][ts:te+1]
+        months = self.wxdset['Month'][ts:te+1]
+        days = self.wxdset['Day'][ts:te+1]
+        self.wl_date = self.convert_time_to_date(years, months, days)
+
 
     def make_data_daily(self, t, h):
         """
@@ -252,7 +242,7 @@ class RechgEvalWorker(QObject):
 
         self.glue_results['wl_time'] = self.twlvl
         self.glue_results['wl_obs'] = self.WLVLobs
-        self.glue_results['wl_date'] = self.DATE
+        self.glue_results['wl_date'] = self.wl_date
         self.glue_results['hydrograph'] = set_WLVL
 
         self.glue_results['Sy'] = set_Sy

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -129,7 +129,7 @@ class RechgEvalWorker(QObject):
         years = self.wxdset['Year'][ts:te+1]
         months = self.wxdset['Month'][ts:te+1]
         days = self.wxdset['Day'][ts:te+1]
-        self.wl_date = self.convert_time_to_date(years, months, days)
+        self.wl_date = convert_date_to_datetime(years, months, days)
 
         return None
 
@@ -152,17 +152,6 @@ class RechgEvalWorker(QObject):
                 hd[i] = h[indx[-1]]
 
         return td, hd
-
-    @staticmethod
-    def convert_time_to_date(years, months, days):
-        """
-        Produce datetime series from years, months, and days series.
-        """
-        dates = [0] * len(years)
-        for t in range(len(years)):
-            dates[t] = datetime.datetime(
-                    int(years[t]), int(months[t]), int(days[t]), 0)
-        return dates
 
     def calc_recharge(self, data=None):
         data = self.glue_results
@@ -500,6 +489,17 @@ class RechgEvalWorker(QObject):
             RECHG[i] *= np.sign(hp - hobs[i+1])
 
         return RECHG
+
+
+def convert_date_to_datetime(years, months, days):
+    """
+    Produce datetime series from years, months, and days series.
+    """
+    dates = [0] * len(years)
+    for t in range(len(years)):
+        dates[t] = datetime.datetime(
+                int(years[t]), int(months[t]), int(days[t]), 0)
+    return dates
 
 
 def calcul_rmse(Xobs, Xpre):

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -135,24 +135,22 @@ class RechgEvalWorker(QObject):
         self.PRECIP = self.wxdset['Ptot'][ts:te+1]
 
     def make_data_daily(self, t, h):
+        """
+        Convert a given time series to a daily basis. Only the last water level
+        measurements made on a given day is kept in the daily time series.
+        If there is no measurement at all for a given day, the default nan
+        value is kept instead in the daily time series.
+        """
         argsort = np.argsort(t)
         t = np.floor(t[argsort])
         h = h[argsort]
 
-        tmin = np.min(t)
-        tmax = np.max(t)
-        t1d = np.arange(tmin, tmax+1, 1)
-        h1d = np.ones(len(t1d))*np.nan
-
-        # Only the last water level measurements made on that day will be
-        # kept in the h1d time series.
-        # If there is no measurement at all, the default nan value is
-        # kept instead in the h1d time series.
-
-        for i in range(len(t1d)):
-            indx = np.where(t == t1d[i])[0]
+        td = np.arange(np.min(t), np.max(t)+1, 1).astype(int)
+        hd = np.ones(len(td)) * np.nan
+        for i in range(len(td)):
+            indx = np.where(t == td[i])[0]
             if len(indx) > 0:
-                h1d[i] = h[indx[-1]]
+                hd[i] = h[indx[-1]]
 
         return t1d, h1d
 

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -356,20 +356,25 @@ class RechgEvalWorker(QObject):
         """
         Compute recharge with a daily soil surface moisture balance model.
 
-        RU = Runoff coefficient
-        RASmax = Readily Available Storage Max in mm
-        ETP = Dailty evapotranspiration in mm
+        CRU = Surface runoff coefficient
+        RASmax = Maximum readily available storage in mm
+        ETP = Dailty potential evapotranspiration in mm
         PTOT = Daily total precipitation in mm
         TAVG = Daily average air temperature in deg. C.
         CM = Daily melt coefficient
         TMELT = Temperature treshold for snowmelt
-        RECHG = Daily groundwater recharge in mm
+
+        rechg = Daily groundwater recharge in mm
+        etr = Daily real evapotranspiration in mm
+        ru = Daily surface runoff in mm
+        ras = Daily readily available storage in mm
+        pacc = Daily accumulated precipitation on the ground surface in mm
         """
-        RECHG, RU, ETR, RAS, PACC = calcul_surf_water_budget(
+        rechg, ru, etr, ras, pacc = calcul_surf_water_budget(
                 self.ETP, self.PTOT, self.TAVG, self.TMELT,
                 self.CM,  CRU, RASmax)
 
-        return RECHG, RU, ETR, RAS, PACC
+        return rechg, ru, etr, ras, pacc
 
     def calc_hydrograph(self, RECHG, Sy, nscheme='forward'):
         """

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -50,9 +50,7 @@ class RechgEvalWorker(QObject):
         self.Cro = (0, 1)
         self.RASmax = (0, 150)
 
-        self.language = 'French'
         self.glue_results = None
-        self.fig = None
         self.glue_pardist_res = 'fine'
 
     @property

--- a/gwhat/gwrecharge/gwrecharge_gui.py
+++ b/gwhat/gwrecharge/gwrecharge_gui.py
@@ -257,7 +257,9 @@ class RechgEvalWidget(QFrameLayout):
         self.rechg_worker.CM = self.CM
         self.rechg_worker.deltat = self.deltaT
 
-        self.rechg_worker.load_data(self.wxdset, self.wldset)
+        error = self.rechg_worker.load_data(self.wxdset, self.wldset)
+        if error is not None:
+            QMessageBox.warning(self, 'Warning', error, QMessageBox.Ok)
 
         # Start the thread
 


### PR DESCRIPTION
Fixes #165 

The class `RechgEvalWorker` was refactored in this PR in order to:

- Check that the observed water level and weather data are not mutually exclusive in time, and to emit a warning message to the user if it is the case.
- Clip the observed water level to the weather dataset to prevent a crash.
- Clean the variables names in order to make the code easier to understand and less prone to error