### PR TITLE
PR: Prevent GWHAT from crashing when evaluating recharge and deltat is not zero

### DIFF
--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -544,14 +544,14 @@ def calcul_glue(data, p, varname='recharge'):
 
 def calcul_glue_yearly_rechg(data, p, yrs_range=None):
     glue_rechg_dly = calcul_glue(data, p, varname='recharge')
-
     years = np.array(data['Year']).astype(int)
     months = np.array(data['Month']).astype(int)
-    deltat = data['deltat']
-    if deltat > 0:
-        Time = np.array(data['Time'])
-        for i, t in enumerate(Time):
-            date = xldate_as_tuple(t+deltat, 0)
+
+    if data['deltat'] > 0:
+        # Adjust time to take into account the time delay, which represents
+        # the percolation time of water through the unsaturated zone.
+        for i, t in enumerate(np.array(data['Time'])):
+            date = xldate_as_tuple(t + data['deltat'], 0)
             years[i], months[i] = date[0], date[1]
 
     # Convert daily to hydrological year. An hydrological year is defined from

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -542,7 +542,7 @@ def calcul_glue(data, p, varname='recharge'):
     return glue_dly
 
 
-def calcul_glue_yearly_rechg(data, p, yrs_range=None):
+def calcul_glue_yearly_rechg(data, p, year_limits=None):
     glue_rechg_dly = calcul_glue(data, p, varname='recharge')
     years = np.array(data['Year']).astype(int)
     months = np.array(data['Month']).astype(int)
@@ -554,18 +554,23 @@ def calcul_glue_yearly_rechg(data, p, yrs_range=None):
             date = xldate_as_tuple(t + data['deltat'], 0)
             years[i], months[i] = date[0], date[1]
 
+    # Define the range of the years for which yearly recharge will be computed.
+
+    if year_limits:
+        year_min = max(min(year_limits), np.min(years))
+        year_max = min(max(year_limits), np.max(years))
+    else:
+        year_min = np.min(years)
+        year_max = np.max(years)
+    year_range = np.arange(year_min, year_max).astype('int')
+
     # Convert daily to hydrological year. An hydrological year is defined from
     # October 1 to September 30 of the next year.
 
-    if yrs_range:
-        yrs2plot = np.arange(yrs_range[0], yrs_range[1]).astype('int')
-    else:
-        yrs2plot = np.arange(np.min(years), np.max(years)).astype('int')
-
-    glue_rechg_yr = np.zeros((len(yrs2plot), len(p)))
+    glue_rechg_yr = np.zeros((len(year_range), len(p)))
     year_labels = []
-    for i in range(len(yrs2plot)):
-        yr0 = yrs2plot[i]
+    for i in range(len(year_range)):
+        yr0 = year_range[i]
         yr1 = yr0 + 1
         year_labels.append("'%s-'%s" % (str(yr0)[-2:], str(yr1)[-2:]))
 
@@ -577,7 +582,7 @@ def calcul_glue_yearly_rechg(data, p, yrs_range=None):
 
         glue_rechg_yr[i, :] = np.sum(glue_rechg_dly[indx0:indx1+1, :], axis=0)
 
-    return year_labels, glue_rechg_yr
+    return year_labels, year_range, glue_rechg_yr
 
 
 # ---- if __name__ == '__main__'

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -230,13 +230,13 @@ class FigYearlyRechgGLUE(FigResultsBase):
         margins[-1] = 1.1
         self.set_ax_margins_inches(self.ax0, margins)
 
-    def plot_recharge(self, data, Ymin0=None, Ymax0=None, yrs_range=None):
+    def plot_recharge(self, data, Ymin0=None, Ymax0=None, year_limits=None):
         fig = self.figure
         ax0 = self.ax0
 
         p = [0.05, 0.25, 0.5, 0.75, 0.95]
-        year_labels, glue_rechg_yr = calcul_glue_yearly_rechg(
-                data, p, yrs_range)
+        year_labels, year_range, glue_rechg_yr = calcul_glue_yearly_rechg(
+                data, p, year_limits)
 
         max_rechg_yrly = glue_rechg_yr[:, -1]
         min_rechg_yrly = glue_rechg_yr[:, 0]
@@ -246,14 +246,8 @@ class FigYearlyRechgGLUE(FigResultsBase):
 
         # ---- Axis range
 
-        if yrs_range:
-            yrs2plot = np.arange(yrs_range[0], yrs_range[1]).astype('int')
-        else:
-            years = np.array(data['Year']).astype(int)
-            yrs2plot = np.arange(np.min(years), np.max(years)).astype('int')
-
-        Xmin0 = min(yrs2plot)-1
-        Xmax0 = max(yrs2plot)+1
+        Xmin0 = min(year_range)-1
+        Xmax0 = max(year_range)+1
 
         if Ymax0 is None:
             Ymax0 = np.max(max_rechg_yrly) + 50
@@ -264,7 +258,7 @@ class FigYearlyRechgGLUE(FigResultsBase):
 
         ax0.xaxis.set_ticks_position('bottom')
         ax0.tick_params(axis='x', direction='out', pad=1)
-        ax0.set_xticks(yrs2plot)
+        ax0.set_xticks(year_range)
         ax0.xaxis.set_ticklabels(year_labels, rotation=45, ha='right')
 
         # ----- ticks format
@@ -288,17 +282,18 @@ class FigYearlyRechgGLUE(FigResultsBase):
 
         # ---- Plot results
 
-        ax0.plot(yrs2plot, prob_rechg_yrly, ls='--', color='0.35', zorder=100)
+        ax0.plot(year_range, prob_rechg_yrly, ls='--', color='0.35',
+                 zorder=100)
 
         yerr = [prob_rechg_yrly-min_rechg_yrly, max_rechg_yrly-prob_rechg_yrly]
-        herr = ax0.errorbar(yrs2plot, prob_rechg_yrly, yerr=yerr,
+        herr = ax0.errorbar(year_range, prob_rechg_yrly, yerr=yerr,
                             fmt='o', capthick=1, capsize=4, ecolor='0',
                             elinewidth=1, mfc='White', mec='0', ms=5,
                             markeredgewidth=1, zorder=200)
 
-        h25 = ax0.plot(yrs2plot, glue25_yr, color='red',
+        h25 = ax0.plot(year_range, glue25_yr, color='red',
                        dashes=[3, 5], alpha=0.65)
-        ax0.plot(yrs2plot, glue75_yr, color='red', dashes=[3, 5], alpha=0.65)
+        ax0.plot(year_range, glue75_yr, color='red', dashes=[3, 5], alpha=0.65)
 
         # ---- Axes labels
 
@@ -346,7 +341,7 @@ class FigYearlyRechgGLUE(FigResultsBase):
                  transform=transform)
 
 
-# ---- if __name__ == '__main__'
+# %% ---- if __name__ == '__main__'
 
 if __name__ == '__main__':
     from gwhat.gwrecharge.gwrecharge_calc2 import RechgEvalWorker


### PR DESCRIPTION
Fixes #167 
This was caused by the deltat, which sometimes caused a shift in the range of years, which was not accounted for in the function to plot the results.