### PR TITLE
PR: Prevent GWHAT from crashing when evaluating recharge before a MRC has been defined

### DIFF
--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -101,10 +101,14 @@ class RechgEvalWorker(QObject):
         self.twlvl, self.wlobs = self.make_data_daily(wldset['Time'],
                                                       wldset['WL'])
 
+        if not self.A and not self.B:
+            error = ("Groundwater recharge cannot be computed because a"
+                     " master recession curve (MRC) must be defined first.")
+            return error
+
         # Check that the wldset and wxdset are not mutually exclusive.
         time = np.unique(np.hstack([self.tweatr, self.twlvl]))
         if len(time) == (len(self.tweatr) + len(self.twlvl)):
-            self.__ready_to_run = False
             error = ("Groundwater recharge cannot be computed because the"
                      " water level and weather datasets are mutually"
                      " exclusive in time.")

--- a/gwhat/gwrecharge/gwrecharge_gui.py
+++ b/gwhat/gwrecharge/gwrecharge_gui.py
@@ -245,9 +245,8 @@ class RechgEvalWidget(QFrameLayout):
         uncertainty.
         """
         plt.close('all')
-        self.progressbar.show()
 
-        # Set the parameter ranges
+        # Set the parameter ranges.
 
         self.rechg_worker.Sy = self.get_Range('Sy')
         self.rechg_worker.Cro = self.get_Range('Cro')
@@ -257,12 +256,16 @@ class RechgEvalWidget(QFrameLayout):
         self.rechg_worker.CM = self.CM
         self.rechg_worker.deltat = self.deltaT
 
+        # Set the data and check for errors.
+
         error = self.rechg_worker.load_data(self.wxdset, self.wldset)
         if error is not None:
             QMessageBox.warning(self, 'Warning', error, QMessageBox.Ok)
+            return
 
-        # Start the thread
+        # Start the computation of groundwater recharge.
 
+        self.progressbar.show()
         waittime = 0
         while self.rechg_thread.isRunning():
             time.sleep(0.1)


### PR DESCRIPTION
Fixes #163

Check if A and B are both zero or None. If yes, prevent the evaluation of groundwater recharge and show a warning message to the user.

![image](https://user-images.githubusercontent.com/10170372/37211719-de88390a-237a-11e8-9dda-12afeec0e4fb.png)
