### PR TITLE
PR: Refactoring the plotting of GLUE results

### DIFF
--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -921,8 +921,8 @@ if __name__ == "__main__":
     import gwhat.projet.reader_projet as prd
     import sys
     # projet = prd.ProjetReader("C:/Users/jsgosselin/GWHAT/Projects/Example/"
-    #                            "Example.gwt")
-    projet = prd.ProjetReader("C:/Users/jsgosselin/GWHAT/gwhat/"
+                                # "Example.gwt")
+    projet = prd.ProjetReader("C:/Users/User/gwhat/gwhat/"
                               "tests/@ new-prô'jèt!/@ new-prô'jèt!.gwt")
     wldset = projet.get_wldset(projet.wldsets[0])
 

--- a/gwhat/gwrecharge/gwrecharge_gui.py
+++ b/gwhat/gwrecharge/gwrecharge_gui.py
@@ -20,8 +20,7 @@ from PyQt5.QtWidgets import (QWidget, QGridLayout, QPushButton, QProgressBar,
 
 from gwhat.common.widgets import QFrameLayout, QDoubleSpinBox, HSep
 from gwhat.gwrecharge.gwrecharge_calc2 import RechgEvalWorker
-from gwhat.gwrecharge.gwrecharge_plot_results import (
-        FigManagerRechgGLUE, FigManagerWaterLevelGLUE)
+from gwhat.gwrecharge.gwrecharge_plot_results import FigureStackManager
 
 
 class RechgEvalWidget(QFrameLayout):
@@ -296,11 +295,6 @@ class RechgEvalWidget(QFrameLayout):
             glue_data = self.rechg_worker.glue_results
             # self.rechg_worker.save_glue_to_npy("GLUE.npy")
 
-            fig_wl_glue = FigManagerWaterLevelGLUE()
-            fig_wl_glue.plot_prediction(glue_data)
-
-            fig_rechg_glue = FigManagerRechgGLUE()
-            fig_rechg_glue.plot_recharge(glue_data)
-
-            fig_wl_glue.show()
-            fig_rechg_glue.show()
+            fig_stack = FigureStackManager(parent=self)
+            fig_stack.plot_results(glue_data)
+            fig_stack.show()

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -29,7 +29,8 @@ from PyQt5.QtWidgets import (
 
 from gwhat.gwrecharge.gwrecharge_calc2 import calcul_glue
 from gwhat.gwrecharge.gwrecharge_calc2 import calcul_glue_yearly_rechg
-from gwhat.common import icons
+from gwhat.common import icons, QToolButtonNormal
+from gwhat.mplFigViewer3 import ImageViewer
 
 mpl.rc('font', **{'family': 'sans-serif', 'sans-serif': ['Arial']})
 

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -124,11 +124,13 @@ class FigCanvasBase(FigureCanvasQTAgg):
     """
     This is the base figure format to plot GLUE results.
     """
+    sig_fig_changed = QSignal(MPLFigure)
+
     colors = {'dark grey': '0.65',
               'light grey': '0.85'}
 
-    MARGINS = [1, 0.15, 0.15, 0.65]  # left, top, right, bottom
     FWIDTH, FHEIGHT = 8.5, 5
+    MARGINS = [1, 0.15, 0.15, 0.65]  # left, top, right, bottom
 
     def __init__(self, language='English'):
         super(FigCanvasBase, self).__init__(mpl.figure.Figure())
@@ -168,6 +170,7 @@ class FigCanvasBase(FigureCanvasQTAgg):
             fw = fw / 2.54
             fh = fh / 2.54
         self.figure.set_size_inches(fw, fh)
+        self.sig_fig_changed.emit(self.figure)
 
     def set_fig_language(self, language):
         """
@@ -243,6 +246,7 @@ class FigWaterLevelGLUE(FigCanvasBase):
         """
         self.language = language
         self.set_axes_labels()
+        self.sig_fig_changed.emit(self.figure)
 
     def set_axes_labels(self):
         """
@@ -377,6 +381,7 @@ class FigYearlyRechgGLUE(FigCanvasBase):
         """
         self.language = language
         self.set_axes_labels()
+        self.sig_fig_changed.emit(self.figure)
 
     def set_axes_labels(self):
         """

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -247,11 +247,12 @@ class FigManagerWaterLevelGLUE(FigManagerBase):
     water level versus the observations.
     """
     def __init__(self, parent=None):
-        super(FigManagerWaterLevelGLUE, self).__init__(FigWaterLevelGLUE,
-                                                       parent)
+        super(FigManagerWaterLevelGLUE, self).__init__(
+            FigWaterLevelGLUE, parent)
 
     def plot_prediction(self, glue_data):
-        self.figure.plot_prediction(glue_data)
+        self.figcanvas.plot_prediction(glue_data)
+        self.figviewer.load_mpl_figure(self.figcanvas.figure)
 
 
 class FigManagerRechgGLUE(FigManagerBase):
@@ -263,7 +264,8 @@ class FigManagerRechgGLUE(FigManagerBase):
         super(FigManagerRechgGLUE, self).__init__(FigYearlyRechgGLUE, parent)
 
     def plot_recharge(self, data, Ymin0=None, Ymax0=None, yrs_range=None):
-        self.figure.plot_recharge(data, Ymin0, Ymax0, yrs_range)
+        self.figcanvas.plot_recharge(data, Ymin0, Ymax0, yrs_range)
+        self.figviewer.load_mpl_figure(self.figcanvas.figure)
 
 
 # ---- Figure Canvas

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -157,6 +157,13 @@ class FigCanvasBase(FigureCanvasQTAgg):
         self.ax0.set_position([left, bottom, 1-left-right, 1-top-bottom])
 
 
+    def set_fig_language(self, language):
+        """
+        Set the language of the text shown in the figure. This needs to be
+        impemented in the derived class.
+        """
+        pass
+
 
 class FigWaterLevelGLUE(FigCanvasBase):
     """
@@ -172,11 +179,7 @@ class FigWaterLevelGLUE(FigCanvasBase):
 
         # ---- Axes labels
 
-        if self.language == 'French':
-            label = "Niveau d'eau (m sous la surface)"
-        else:
-            label = 'Water Level (mbgs)'
-        ax.set_ylabel(label, fontsize=16, labelpad=20)
+        self.set_axes_labels()
 
         # ---- Grids
 
@@ -222,6 +225,22 @@ class FigWaterLevelGLUE(FigCanvasBase):
         ax.fill_between(dates, glue_dly[:, -1]/1000, glue_dly[:, 0]/1000,
                         facecolor='0.85', lw=1, edgecolor='0.65', zorder=0)
 
+    def set_fig_language(self, language):
+        """
+        Set the language of the text shown in the figure.
+        """
+        self.language = language
+        self.set_axes_labels()
+
+    def set_axes_labels(self):
+        """
+        Set the text and position of the axes labels.
+        """
+        if self.language == 'French':
+            xlabel = "Niveau d'eau (m sous la surface)"
+        else:
+            xlabel = 'Water Level (mbgs)'
+        self.ax0.set_ylabel(xlabel, fontsize=16, labelpad=20)
 
 
 class FigYearlyRechgGLUE(FigCanvasBase):
@@ -306,16 +325,7 @@ class FigYearlyRechgGLUE(FigCanvasBase):
 
         # ---- Axes labels
 
-        if self.language.lower() == 'french':
-            ylabl = "Recharge annuelle (mm/a)"
-            xlabl = ("Années Hydrologiques (1er octobre d'une année "
-                     "au 30 septembre de la suivante)")
-        else:
-            ylabl = "Annual Recharge (mm/y)"
-            xlabl = ("Hydrological Years (October 1st of one "
-                     "year to September 30th of the next)")
-        ax0.set_ylabel(ylabl, fontsize=16, labelpad=15)
-        ax0.set_xlabel(xlabl, fontsize=16, labelpad=20)
+        self.set_axes_labels()
 
         # ----- Legend
 
@@ -348,6 +358,28 @@ class FigYearlyRechgGLUE(FigCanvasBase):
         transform = ax0.transAxes + padding
         ax0.text(0, 0, text, va='bottom', ha='left', fontsize=10,
                  transform=transform)
+
+    def set_fig_language(self, language):
+        """
+        Set the language of the text shown in the figure.
+        """
+        self.language = language
+        self.set_axes_labels()
+
+    def set_axes_labels(self):
+        """
+        Set the text and position of the axes labels.
+        """
+        if self.language.lower() == 'french':
+            ylabl = "Recharge annuelle (mm/a)"
+            xlabl = ("Années Hydrologiques (1er octobre d'une année "
+                     "au 30 septembre de la suivante)")
+        else:
+            ylabl = "Annual Recharge (mm/y)"
+            xlabl = ("Hydrological Years (October 1st of one "
+                     "year to September 30th of the next)")
+        self.ax0.set_ylabel(ylabl, fontsize=16, labelpad=15)
+        self.ax0.set_xlabel(xlabl, fontsize=16, labelpad=20)
 
 
 # %% ---- if __name__ == '__main__'

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -37,6 +37,34 @@ LOCS = ['left', 'top', 'right', 'bottom']
 LANGUAGES = ['French', 'English']
 
 
+class FigureStackManager(QWidget):
+    def __init__(self, parent=None):
+        super(FigureStackManager, self).__init__(parent)
+        self.setMinimumSize(1250, 650)
+        self.setWindowTitle('Recharge Results')
+        self.setWindowFlags(Qt.Window)
+        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setWindowIcon(icons.get_icon('master'))
+
+        self.setup()
+
+    def setup(self):
+        """Setup the FigureStackManager withthe provided options."""
+        self.setup_stack()
+        layout = QGridLayout(self)
+        layout.addWidget(self.stack, 0, 0)
+
+    def setup_stack(self):
+        self.fig_wl_glue = FigManagerWaterLevelGLUE(self)
+        self.fig_rechg_glue = FigManagerRechgGLUE(self)
+
+        self.stack = QTabWidget()
+        self.stack.addTab(self.fig_wl_glue, 'Hydrograph')
+        self.stack.addTab(self.fig_rechg_glue, 'Recharge')
+
+    def plot_results(self, glue_data):
+        self.fig_wl_glue.plot_prediction(glue_data)
+        self.fig_rechg_glue.plot_recharge(glue_data)
 
 
 # ---- Figure Managers

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -15,9 +15,14 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
+from matplotlib.figure import Figure as MPLFigure
+
 
 from PyQt5.QtCore import Qt, QSize
-from PyQt5.QtWidgets import QGridLayout, QApplication, QDialog
+from PyQt5.QtCore import pyqtSignal as QSignal
+from PyQt5.QtWidgets import (
+    QGridLayout, QApplication, QComboBox, QDoubleSpinBox, QFileDialog,
+    QGroupBox, QLabel, QTabWidget, QToolBar, QWidget)
 
 
 # ---- Imports: local

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -33,6 +33,10 @@ from gwhat.common import icons, QToolButtonNormal
 from gwhat.mplFigViewer3 import ImageViewer
 
 mpl.rc('font', **{'family': 'sans-serif', 'sans-serif': ['Arial']})
+LOCS = ['left', 'top', 'right', 'bottom']
+LANGUAGES = ['French', 'English']
+
+
 
 
 # ---- Figure Managers

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -156,6 +156,18 @@ class FigCanvasBase(FigureCanvasQTAgg):
 
         self.ax0.set_position([left, bottom, 1-left-right, 1-top-bottom])
 
+        self.sig_fig_changed.emit(self.figure)
+
+    def set_fig_size(self, fw, fh, units='IP'):
+        """
+        Set the figure width and height in inches if units is IP
+        or in cm if units is SI.
+        """
+        if units == 'SI':
+            # Convert values from cm to in.
+            fw = fw / 2.54
+            fh = fh / 2.54
+        self.figure.set_size_inches(fw, fh)
 
     def set_fig_language(self, language):
         """

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -127,7 +127,7 @@ class FigCanvasBase(FigureCanvasQTAgg):
     colors = {'dark grey': '0.65',
               'light grey': '0.85'}
 
-    MARGINS = [0.85, 0.15, 0.15, 0.65]  # left, top, right, bottom
+    MARGINS = [1, 0.15, 0.15, 0.65]  # left, top, right, bottom
     FWIDTH, FHEIGHT = 8.5, 5
 
     def __init__(self, language='English'):
@@ -229,6 +229,8 @@ class FigYearlyRechgGLUE(FigCanvasBase):
     This is a graph that shows annual ground-water recharge and its
     uncertainty.
     """
+
+    MARGINS = [1, 0.15, 0.15, 1.1]  # left, top, right, bottom
 
     def __init__(self, *args, **kargs):
         super(FigYearlyRechgGLUE, self).__init__(*args, **kargs)

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -128,14 +128,14 @@ class FigCanvasBase(FigureCanvasQTAgg):
               'light grey': '0.85'}
 
     MARGINS = [0.85, 0.15, 0.15, 0.65]  # left, top, right, bottom
+    FWIDTH, FHEIGHT = 8.5, 5
 
     def __init__(self, language='English'):
         super(FigCanvasBase, self).__init__(mpl.figure.Figure())
 
         self.language = language
 
-        fwidth, fheight = 8.5, 5
-        self.figure.set_size_inches(fwidth, fheight)
+        self.figure.set_size_inches(self.FWIDTH, self.FHEIGHT)
         self.figure.patch.set_facecolor('white')
 
         self.ax0 = ax0 = self.figure.add_axes([0, 0, 1, 1])

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -120,7 +120,7 @@ class FigManagerRechgGLUE(FigManagerBase):
 
 # ---- Figure Canvas
 
-class FigResultsBase(FigureCanvasQTAgg):
+class FigCanvasBase(FigureCanvasQTAgg):
     """
     This is the base figure format to plot GLUE results.
     """
@@ -130,7 +130,7 @@ class FigResultsBase(FigureCanvasQTAgg):
     MARGINS = [0.85, 0.15, 0.15, 0.65]  # left, top, right, bottom
 
     def __init__(self, language='English'):
-        super(FigResultsBase, self).__init__(mpl.figure.Figure())
+        super(FigCanvasBase, self).__init__(mpl.figure.Figure())
 
         self.language = language
 
@@ -157,7 +157,7 @@ class FigResultsBase(FigureCanvasQTAgg):
         ax.set_position([left, bottom, 1-left-right, 1-top-bottom])
 
 
-class FigWaterLevelGLUE(FigResultsBase):
+class FigWaterLevelGLUE(FigCanvasBase):
     """
     This is a graph that shows observed ground-water levels and GLUE 5/95
     predicted water levels.
@@ -223,7 +223,8 @@ class FigWaterLevelGLUE(FigResultsBase):
                         facecolor='0.85', lw=1, edgecolor='0.65', zorder=0)
 
 
-class FigYearlyRechgGLUE(FigResultsBase):
+
+class FigYearlyRechgGLUE(FigCanvasBase):
     """
     This is a graph that shows annual ground-water recharge and its
     uncertainty.

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -139,22 +139,23 @@ class FigCanvasBase(FigureCanvasQTAgg):
         self.figure.patch.set_facecolor('white')
 
         self.ax0 = ax0 = self.figure.add_axes([0, 0, 1, 1])
-        self.set_ax_margins_inches(self.ax0, self.MARGINS)
+        self.set_axes_margins_inches(self.MARGINS)
         ax0.patch.set_visible(False)
         for axis in ['top', 'bottom', 'left', 'right']:
             ax0.spines[axis].set_linewidth(0.5)
 
-    def set_ax_margins_inches(self, ax, margins):
+    def set_axes_margins_inches(self, margins):
+        """Set the margins of the figure axes in inches."""
         fheight = self.figure.get_figheight()
         fwidth = self.figure.get_figwidth()
-        left, top, right, bottom = margins
 
-        left = left/fwidth
-        right = right/fwidth
-        top = top/fheight
-        bottom = bottom/fheight
+        left = margins[0]/fwidth
+        top = margins[1]/fheight
+        right = margins[2]/fwidth
+        bottom = margins[3]/fheight
 
-        ax.set_position([left, bottom, 1-left-right, 1-top-bottom])
+        self.ax0.set_position([left, bottom, 1-left-right, 1-top-bottom])
+
 
 
 class FigWaterLevelGLUE(FigCanvasBase):
@@ -166,9 +167,8 @@ class FigWaterLevelGLUE(FigCanvasBase):
     def __init__(self, *args, **kargs):
         super(FigWaterLevelGLUE, self).__init__(*args, **kargs)
         fig = self.figure
-        ax = self.ax0
 
-        # ---- Customize Ax0 margins
+        ax = self.ax0
 
         # ---- Axes labels
 
@@ -237,11 +237,7 @@ class FigYearlyRechgGLUE(FigCanvasBase):
 
         # ---- Customize Ax0
 
-        self.ax0
         self.ax0.set_axisbelow(True)
-        margins = self.MARGINS
-        margins[-1] = 1.1
-        self.set_ax_margins_inches(self.ax0, margins)
 
     def plot_recharge(self, data, Ymin0=None, Ymax0=None, year_limits=None):
         fig = self.figure

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -557,12 +557,8 @@ if __name__ == '__main__':
     rechg_worker = RechgEvalWorker()
     data = rechg_worker.load_glue_from_npy("..\GLUE.npy")
 
-    glue_wl_viewer = FigManagerWaterLevelGLUE()
-    glue_wl_viewer.plot_prediction(data)
-    glue_wl_viewer.show()
-
-    fig_rechg_glue = FigManagerRechgGLUE()
-    fig_rechg_glue.plot_recharge(data)
-    fig_rechg_glue.show()
+    figstack = FigureStackManager()
+    figstack.plot_results(data)
+    figstack.show()
 
     sys.exit(app.exec_())


### PR DESCRIPTION
The objective of this PR is to plot the results of GLUE within a single window with tabs and to add the possibility to set the size of the figure and of the margins and the language of the text.

There is plans to add more output figures, so this has become necessary because we do not want 3-4 new windows to pop up each time we are doing a groundwater recharge evaluation.

![new_fig_stackmanager](https://user-images.githubusercontent.com/10170372/38637796-3863f390-3d9a-11e8-95af-9e96f7ac835f.gif)
