### PR TITLE
PR: Make the saving of the hydrograph figure more robust

### DIFF
--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -713,14 +713,15 @@ class HydroprintGUI(myqt.DialogWindow):
         Open a dialog where the user can select a file name to save the
         hydrograph.
         """
-        dialog_dir = os.path.join(self.save_fig_dir,
-                                  'hydrograph_%s' % self.wldset['Well'])
         if self.wldset is None:
             return
 
-        dialog = QFileDialog()
-        fname, ftype = dialog.getSaveFileName(
-                self, "Save Figure", dialog_dir, '*.pdf;;*.svg')
+        ffmat = "*.pdf;;*.svg;;*.png"
+        fname = find_unique_filename(osp.join(
+            self.save_fig_dir, 'hydrograph_%s.pdf' % self.wldset['Well']))
+
+        fname, ftype = QFileDialog.getSaveFileName(
+            self, "Save Figure", fname, ffmat)
         if fname:
             ftype = ftype.replace('*', '')
             fname = fname if fname.endswith(ftype) else fname + ftype

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -12,6 +12,7 @@ from __future__ import division, unicode_literals
 
 import sys
 import os
+import os.path as osp
 
 # ---- Third party imports
 
@@ -36,6 +37,7 @@ from gwhat.colors2 import ColorsReader, ColorsSetupWin
 from gwhat.common import QToolButtonNormal, QToolButtonSmall
 from gwhat.common import icons
 import gwhat.common.widgets as myqt
+from gwhat.common.utils import find_unique_filename
 from gwhat.projet.reader_waterlvl import load_waterlvl_measures
 
 
@@ -722,7 +724,13 @@ class HydroprintGUI(myqt.DialogWindow):
             if not fname.endswith(ftype):
                 fname = fname + ftype
             self.save_fig_dir = os.path.dirname(fname)
-            self.save_figure(fname)
+
+            try:
+                self.save_figure(fname)
+            except PermissionError:
+                msg = "The file is in use by another application or user."
+                QMessageBox.warning(self, 'Warning', msg, QMessageBox.Ok)
+                self.select_save_path()
 
     def save_figure(self, fname):
         """Save the hydrograph figure in a file."""

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -719,10 +719,9 @@ class HydroprintGUI(myqt.DialogWindow):
         dialog = QFileDialog()
         fname, ftype = dialog.getSaveFileName(
                 self, "Save Figure", dialog_dir, '*.pdf;;*.svg')
-        ftype = ftype.replace('*', '')
         if fname:
-            if not fname.endswith(ftype):
-                fname = fname + ftype
+            ftype = ftype.replace('*', '')
+            fname = fname if fname.endswith(ftype) else fname + ftype
             self.save_fig_dir = os.path.dirname(fname)
 
             try:

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -710,8 +710,8 @@ class HydroprintGUI(myqt.DialogWindow):
 
     def select_save_path(self):
         """
-        Opens a dialog which allows to select a file path where the hydrograph
-        figure can be saved.
+        Open a dialog where the user can select a file name to save the
+        hydrograph.
         """
         dialog_dir = os.path.join(self.save_fig_dir,
                                   'hydrograph_%s' % self.wldset['Well'])

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -715,6 +715,8 @@ class HydroprintGUI(myqt.DialogWindow):
         """
         dialog_dir = os.path.join(self.save_fig_dir,
                                   'hydrograph_%s' % self.wldset['Well'])
+        if self.wldset is None:
+            return
 
         dialog = QFileDialog()
         fname, ftype = dialog.getSaveFileName(


### PR DESCRIPTION
Fixes #177

- Prevent GWHAT from crashing when the save button is clicked but no hydrograph is actually plotted.
- Prevent GWHAT from crashing when saving a figure in a file that is opened in another application.
- Add a number at the end of the proposed figure name if the default name already exist.
- Add the option to save the figure to png.