### PR TITLE
PR: Add graphs of average yearly and monthly water budget.

### DIFF
--- a/gwhat/gwrecharge/glue.py
+++ b/gwhat/gwrecharge/glue.py
@@ -208,7 +208,7 @@ def calcul_mly_budget(glue_dly):
                 continue
             for var in ['recharge', 'evapo', 'runoff']:
                 glue_mly[var][i, j, :] = np.sum(
-                    glue_dly['recharge'][indexes, :], axis=0)
+                    glue_dly[var][indexes, :], axis=0)
             glue_mly['precip'][i, j] = np.sum(glue_dly['precip'][indexes])
 
     return glue_mly

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -578,8 +578,7 @@ class YAxisOptPanel(SetpPanelBase):
     def _yaxis_changed(self):
         self.figcanvas.set_ylimits(
             self._spb_ymin.value(), self._spb_ymax.value(),
-            self._spb_yscl.value(), self._spb_yscl_minor.value()
-        )
+            self._spb_yscl.value(), self._spb_yscl_minor.value())
 
 
 # ---- Figure managers

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -1115,11 +1115,11 @@ class FigWaterBudgetGLUE(FigCanvasBase):
         Set the text and position of the axes labels.
         """
         if self.setp['language'] == 'french':
-            ylabel = "Colonne d'eau équivalente (mm)"
+            ylabel = "Colonne d'eau équivalente (mm/an)"
             xlabel = ("Année Hydrologique (1er octobre d'une"
                       " année au 30 septembre de l'année suivante)")
         else:
-            ylabel = 'Equivalent Water (mm)'
+            ylabel = 'Equivalent Water (mm/y)'
             xlabel = ("Hydrological Years (October 1st of one"
                       " year to September 30th of the next)")
 

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -236,46 +236,12 @@ class MarginSizePanel(SetpPanelBase):
 
 
 class TextOptPanel(SetpPanelBase):
-    def __init__(self, parent=None):
-        super(TextOptPanel, self).__init__(parent)
-        self.setup()
+    def __init__(self, **kwargs):
+        super(TextOptPanel, self).__init__(parent=None)
+        self.setup(**kwargs)
 
-    def setup(self):
-        """Setup the gui of the panel."""
-        self.layout().addWidget(self._setup_textprop_grpbox())
-        self.layout().setRowStretch(self.layout().rowCount(), 100)
-
-    @QSlot(dict)
-    def update_from_setp(self, setp):
-        self._spb_xlabelsize.blockSignals(True)
-        self._spb_xlabelsize.setValue(setp['xlabel size'])
-        self._spb_xlabelsize.blockSignals(False)
-
-        self._spb_xticksize.blockSignals(True)
-        self._spb_xticksize.setValue(setp['xticks size'])
-        self._spb_xticksize.blockSignals(False)
-
-        self._spb_ylabelsize.blockSignals(True)
-        self._spb_ylabelsize.setValue(setp['ylabel size'])
-        self._spb_ylabelsize.blockSignals(False)
-
-        self._spb_ylabelsize.blockSignals(True)
-        self._spb_ylabelsize.setValue(setp['ylabel size'])
-        self._spb_ylabelsize.blockSignals(False)
-
-        self._spb_yticksize.blockSignals(True)
-        self._spb_yticksize.setValue(setp['yticks size'])
-        self._spb_yticksize.blockSignals(False)
-
-        self._spb_yticksize.blockSignals(True)
-        self._spb_legendsize.setValue(setp['legend size'])
-        self._spb_yticksize.blockSignals(False)
-
-        self._spb_notesize.blockSignals(True)
-        self._spb_notesize.setValue(setp['notes size'])
-        self._spb_notesize.blockSignals(False)
-
-    def _setup_textprop_grpbox(self):
+    def setup(self, xlabelsize=True, xticksize=True, ylabelsize=True,
+              yticksize=True, legendsize=True, notesize=True):
         """
         Setup a group box with widgets that allows to set the figure
         text properties.
@@ -325,24 +291,68 @@ class TextOptPanel(SetpPanelBase):
         grpbox = QGroupBox("Text Properties :")
         layout = QGridLayout(grpbox)
 
-        layout.addWidget(QLabel('xlabel size:'), 0, 0)
-        layout.addWidget(self._spb_xlabelsize, 0, 2)
-        layout.addWidget(QLabel('xticks size:'), 1, 0)
-        layout.addWidget(self._spb_xticksize, 1, 2)
-        layout.addWidget(QLabel('ylabel size:'), 2, 0)
-        layout.addWidget(self._spb_ylabelsize, 2, 2)
-        layout.addWidget(QLabel('yticks size:'), 3, 0)
-        layout.addWidget(self._spb_yticksize, 3, 2)
-        layout.addWidget(QLabel('legend size:'), 4, 0)
-        layout.addWidget(self._spb_legendsize, 4, 2)
-        layout.addWidget(QLabel('notes size:'), 5, 0)
-        layout.addWidget(self._spb_notesize, 5, 2)
+        if xlabelsize:
+            layout.addWidget(QLabel('xlabel size:'), 0, 0)
+            layout.addWidget(self._spb_xlabelsize, 0, 2)
+        self._spb_xlabelsize.setVisible(xlabelsize)
+        if xticksize:
+            layout.addWidget(QLabel('xticks size:'), 1, 0)
+            layout.addWidget(self._spb_xticksize, 1, 2)
+        self._spb_xticksize.setVisible(xticksize)
+        if ylabelsize:
+            layout.addWidget(QLabel('ylabel size:'), 2, 0)
+            layout.addWidget(self._spb_ylabelsize, 2, 2)
+        self._spb_ylabelsize.setVisible(ylabelsize)
+        if yticksize:
+            layout.addWidget(QLabel('yticks size:'), 3, 0)
+            layout.addWidget(self._spb_yticksize, 3, 2)
+        self._spb_yticksize.setVisible(yticksize)
+        if legendsize:
+            layout.addWidget(QLabel('legend size:'), 4, 0)
+            layout.addWidget(self._spb_legendsize, 4, 2)
+        self._spb_legendsize.setVisible(legendsize)
+        if notesize:
+            layout.addWidget(QLabel('notes size:'), 5, 0)
+            layout.addWidget(self._spb_notesize, 5, 2)
+        self._spb_notesize.setVisible(notesize)
 
         layout.setColumnStretch(1, 100)
         layout.setContentsMargins(10, 10, 10, 10)  # (L, T, R, B)
 
-        return grpbox
+        self.layout().addWidget(grpbox)
+        self.layout().setRowStretch(self.layout().rowCount(), 100)
 
+    @QSlot(dict)
+    def update_from_setp(self, setp):
+        self._spb_xlabelsize.blockSignals(True)
+        self._spb_xlabelsize.setValue(setp['xlabel size'])
+        self._spb_xlabelsize.blockSignals(False)
+
+        self._spb_xticksize.blockSignals(True)
+        self._spb_xticksize.setValue(setp['xticks size'])
+        self._spb_xticksize.blockSignals(False)
+
+        self._spb_ylabelsize.blockSignals(True)
+        self._spb_ylabelsize.setValue(setp['ylabel size'])
+        self._spb_ylabelsize.blockSignals(False)
+
+        self._spb_ylabelsize.blockSignals(True)
+        self._spb_ylabelsize.setValue(setp['ylabel size'])
+        self._spb_ylabelsize.blockSignals(False)
+
+        self._spb_yticksize.blockSignals(True)
+        self._spb_yticksize.setValue(setp['yticks size'])
+        self._spb_yticksize.blockSignals(False)
+
+        self._spb_yticksize.blockSignals(True)
+        self._spb_legendsize.setValue(setp['legend size'])
+        self._spb_yticksize.blockSignals(False)
+
+        self._spb_notesize.blockSignals(True)
+        self._spb_notesize.setValue(setp['notes size'])
+        self._spb_notesize.blockSignals(False)
+
+    @QSlot()
     def _legend_changed(self):
         self.figcanvas.set_legend_fontsize(self._spb_legendsize.value())
 

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -1418,6 +1418,124 @@ class FigYearlyRechgGLUE(FigCanvasBase):
             numpoints=1, bbox_to_anchor=[0, 1], loc='upper left')
 
 
+
+class FigAvgMonthlyBudget(FigCanvasBase):
+    """
+    This is a graph that shows average monthly values of the water budget
+    components calculated with GLUE at the 0.5 limit.
+    """
+    FIGNAME = "avg_monthly_water_budget"
+    FWIDTH, FHEIGHT = 8, 4.5
+    MARGINS = [1, 0.35, 0.15, 0.35]
+    COLOR = [[102/255, 178/255, 255/255],
+             [0/255, 128/255, 255/255],
+             [0/255, 76/255, 153/255],
+             [0/255, 25/255, 51/255]]
+
+    def __init__(self, setp={}):
+        super(FigAvgMonthlyBudget, self).__init__(setp)
+        self._xticklabels_yt = 5
+        self.lg_handles = []
+        self.setp['xticks size'] = 14
+        self.setp['yticks size'] = 14
+        self.setp['notes size'] = 12
+        self.setp['ylabel size'] = 16
+        self.setp['legend size'] = 12
+
+    def plot(self, glue_df):
+        """Plot the results."""
+        super(FigAvgMonthlyBudget, self).plot()
+        avg_mly = [
+            np.nanmean(glue_df['monthly budget']['evapo'][:, :, 2], axis=0),
+            np.nanmean(glue_df['monthly budget']['runoff'][:, :, 2], axis=0),
+            np.nanmean(glue_df['monthly budget']['recharge'][:, :, 2], axis=0),
+            np.nanmean(glue_df['monthly budget']['precip'], axis=0)]
+
+        # Plot the results.
+        months = np.arange(1, 13)
+        for i, ser in enumerate(avg_mly):
+            hl, = self.ax0.plot(months, ser, marker='o', mec='white',
+                                clip_on=False, lw=2, color=self.COLOR[i],
+                                zorder=3)
+            self.lg_handles.append(hl)
+
+        # Setup the axis limits.
+        if 'ymin' not in self.setp.keys():
+            self.setp['ymin'] = 0
+        if 'ymax' not in self.setp.keys():
+            self.setp['ymax'] = np.max(avg_mly) + 10
+        if 'yscl' not in self.setp.keys():
+            self.setp['yscl'] = 50
+        if 'yscl minor' not in self.setp.keys():
+            self.setp['yscl minor'] = 10
+        self.setup_ylimits()
+        self.ax0.axis(xmin=0.5, xmax=12.5)
+        self.ax0.set_xticks(months)
+
+        # Setup ticks.
+        self.setup_xticklabels()
+        self.setup_yticklabels()
+
+        # Setup grid and axes labels.
+        self.ax0.grid(axis='y', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)
+        self.ax0.set_axisbelow(True)
+        self.setup_axes_labels()
+
+        self.setup_axes_labels()
+        self.setup_legend()
+
+        self.sig_fig_changed.emit(self.figure)
+        self.sig_newfig_plotted.emit(self.setp)
+
+    def setup_language(self):
+        """Setup the language of the text shown in the figure."""
+        self.setup_axes_labels()
+        self.setup_xticklabels()
+        self.setup_legend()
+
+    def setup_axes_labels(self):
+        """Set the text and position of the axes labels."""
+        if self.setp['language'] == 'french':
+            ylabel = "Colonne d'eau équivalente (mm/mois)"
+        else:
+            ylabel = 'Equivalent Water (mm/month)'
+        self.ax0.set_ylabel(ylabel, fontsize=self.setp['ylabel size'],
+                            labelpad=10)
+
+    def setup_yticklabels(self):
+        """Setup the labels of the yaxis."""
+        self.ax0.tick_params(axis='y', direction='out', gridOn=True,
+                             labelsize=self.setp['yticks size'])
+        self.ax0.tick_params(axis='y', direction='out', which='minor',
+                             gridOn=False)
+
+    def setup_xticklabels(self):
+        """Setup the labels of the xaxis."""
+        if self.setp['language'] == 'french':
+            labels = ['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Jun',
+                      'Jul', 'Aoû', 'Sep', 'Oct', 'Nov', 'Déc']
+        else:
+            labels = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+        self.ax0.set_xticklabels(labels)
+        self.ax0.tick_params(axis='x', gridOn=True, length=0, pad=6,
+                             labelsize=self.setp['xticks size'])
+
+    def setup_legend(self):
+        """Setup the legend of the graph."""
+        if self.setp['language'] == 'french':
+            labels = ['Évapotranspiration', 'Ruissellement',
+                      'Recharge', 'Précipitations']
+        else:
+            labels = ['Evapotranspiration', 'Runoff',
+                      'Recharge', 'Precipitation']
+        legend = self.ax0.legend(
+            self.lg_handles, labels, numpoints=1, borderaxespad=0,
+            loc='lower left', borderpad=0.5, bbox_to_anchor=(0, 1, 1, 1),
+            ncol=4, mode="expand", fontsize=self.setp['legend size'])
+        legend.draw_frame(False)
+
+
 # %% ---- if __name__ == '__main__'
 
 if __name__ == '__main__':

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -52,7 +52,7 @@ class FigureStackManager(QWidget):
                             Qt.WindowMinimizeButtonHint |
                             Qt.WindowCloseButtonHint)
         self.setWindowIcon(icons.get_icon('master'))
-
+        self.figmanagers = []
         self.setup()
 
     def setup(self):
@@ -62,40 +62,55 @@ class FigureStackManager(QWidget):
         layout.addWidget(self.stack, 0, 0)
 
     def setup_stack(self):
-        self.fig_wl_glue = FigManagerBase(
+        fig_wl_glue = FigManagerBase(
             FigWaterLevelGLUE,
             setp_panels=[FigSizePanel(),
                          MarginSizePanel()])
-        self.fig_rechg_glue = FigManagerBase(
+        fig_rechg_glue = FigManagerBase(
             FigYearlyRechgGLUE,
             setp_panels=[FigSizePanel(),
                          MarginSizePanel(),
                          YAxisOptPanel(),
                          YearLimitsPanel(),
                          TextOptPanel()])
-        self.fig_watbudg_glue = FigManagerBase(
+        fig_watbudg_glue = FigManagerBase(
             FigWaterBudgetGLUE,
             setp_panels=[FigSizePanel(),
                          MarginSizePanel(),
                          YAxisOptPanel(),
                          YearLimitsPanel(),
                          TextOptPanel()])
+        fig_avg_yearly_budg = FigManagerBase(
+            FigAvgYearlyBudget,
+            setp_panels=[FigSizePanel(),
+                         MarginSizePanel(),
+                         YAxisOptPanel(),
+                         TextOptPanel(xlabelsize=False, legendsize=False)])
+        fig_avg_monthly_budg = FigManagerBase(
+            FigAvgMonthlyBudget,
+            setp_panels=[FigSizePanel(),
+                         MarginSizePanel(),
+                         YAxisOptPanel(),
+                         TextOptPanel(xlabelsize=False, notesize=False)])
+
+        self.figmanagers = [fig_wl_glue, fig_rechg_glue, fig_watbudg_glue,
+                            fig_avg_yearly_budg, fig_avg_monthly_budg]
 
         self.stack = QTabWidget()
-        self.stack.addTab(self.fig_wl_glue, 'Hydrograph')
-        self.stack.addTab(self.fig_rechg_glue, 'Recharge')
-        self.stack.addTab(self.fig_watbudg_glue, 'Water Budget')
+        self.stack.addTab(fig_wl_glue, 'Hydrograph')
+        self.stack.addTab(fig_rechg_glue, 'Recharge')
+        self.stack.addTab(fig_watbudg_glue, 'Yearly Budget')
+        self.stack.addTab(fig_avg_yearly_budg, 'Yearly Avg. Budget')
+        self.stack.addTab(fig_avg_monthly_budg, 'Monthly Avg. Budget')
 
     def plot_results(self, glue_df):
-        self.fig_wl_glue.figcanvas.plot(glue_df)
-        self.fig_rechg_glue.figcanvas.plot(glue_df)
-        self.fig_watbudg_glue.figcanvas.plot(glue_df)
+        for figmanager in self.figmanagers:
+            figmanager.figcanvas.plot(glue_df)
 
     def clear_figures(self):
         """Clear the figures of all figure canvas of the stack."""
-        self.fig_wl_glue.figcanvas.clear_figure(silent=False)
-        self.fig_rechg_glue.figcanvas.clear_figure(silent=False)
-        self.fig_watbudg_glue.figcanvas.clear_figure(silent=False)
+        for figmanager in self.figmanagers:
+            figmanager.figcanvas.clear_figure(silent=False)
 
 
 # ---- Figure setp panels

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -899,7 +899,7 @@ class FigCanvasBase(FigureCanvasQTAgg):
         """
         Calcul the vertical padding in points between the xaxis and its label.
         This corresponds to the sum of the xtick labels height and their
-        vertical padding.
+        vertical padding in points.
         """
         # Random text bbox height :
         renderer = self.get_renderer()
@@ -942,13 +942,11 @@ class FigWaterBudgetGLUE(FigCanvasBase):
 
     def __init__(self, setp={}):
         super(FigWaterBudgetGLUE, self).__init__(setp)
-        self._xticklabels_yt = -2/72
+        self._xticklabels_yt = 2
 
     def plot(self, glue_df):
-        if self.ax0 is None:
-            self.setup_ax()
+        super(FigWaterBudgetGLUE, self).plot()
         ax = self.ax0
-        self.clear_ax()
 
         glue_yrly = glue_df['hydrol yearly budget']
         years = glue_yrly['years']
@@ -975,10 +973,10 @@ class FigWaterBudgetGLUE(FigCanvasBase):
         self.setp['ymin'] = 0
         self.setp['ymax'] = np.ceil(np.max(precip)/100)*100
         self.setp['yscl'] = 250
-        self.setp['yscl_minor'] = 50
+        self.setp['yscl minor'] = 50
 
         self.set_ylimits(self.setp['ymin'], self.setp['ymax'],
-                         self.setp['yscl'], self.setp['yscl_minor'])
+                         self.setp['yscl'], self.setp['yscl minor'])
         self.set_xlimits(self.setp['xmin'], self.setp['xmax'])
 
         self.setup_axes_labels()
@@ -1074,7 +1072,7 @@ class FigWaterBudgetGLUE(FigCanvasBase):
 
         xt = self._get_xlabel_xt(self.setp['xticks size'], 45)
         offset = mpl.transforms.ScaledTranslation(
-            xt, self._xticklabels_yt, self.figure.dpi_scale_trans)
+            xt, -self._xticklabels_yt/72, self.figure.dpi_scale_trans)
         for i in range(len(year_range)):
             self.xticklabels.append(self.ax0.text(
                 year_range[i], self.setp['ymin'], xlabels[i], rotation=45,
@@ -1161,9 +1159,7 @@ class FigWaterLevelGLUE(FigCanvasBase):
         super(FigWaterLevelGLUE, self).__init__(setp)
 
     def plot(self, glue_df):
-        if self.ax0 is None:
-            self.setup_ax()
-        self.clear_ax()
+        super(FigWaterLevelGLUE, self).plot()
         ax = self.ax0
 
         ax.grid(axis='x', color='0.35', ls=':', lw=1, zorder=200)
@@ -1242,15 +1238,13 @@ class FigYearlyRechgGLUE(FigCanvasBase):
 
     def __init__(self, setp={}):
         super(FigYearlyRechgGLUE, self).__init__(setp)
-        self._xticklabels_yt = -4/72
+        self._xticklabels_yt = 4
         self.setp['legend size'] = 12
         self.setp['xticks size'] = 12
 
     def plot(self, glue_data):
-        if self.ax0 is None:
-            self.setup_ax()
+        super(FigYearlyRechgGLUE, self).plot()
         ax0 = self.ax0
-        self.clear_ax()
         self.ax0.set_axisbelow(True)
 
         year_range = glue_data['hydrol yearly budget']['years']
@@ -1289,10 +1283,10 @@ class FigYearlyRechgGLUE(FigCanvasBase):
         self.setp['ymin'] = ymin0
         self.setp['ymax'] = ymax0
         self.setp['yscl'] = scale_yticks
-        self.setp['yscl_minor'] = scale_yticks_minor
+        self.setp['yscl minor'] = scale_yticks_minor
 
         self.set_ylimits(self.setp['ymin'], self.setp['ymax'],
-                         self.setp['yscl'], self.setp['yscl_minor'])
+                         self.setp['yscl'], self.setp['yscl minor'])
         self.set_xlimits(self.setp['xmin'], self.setp['xmax'])
 
         # ---- Plot results
@@ -1345,7 +1339,7 @@ class FigYearlyRechgGLUE(FigCanvasBase):
 
         xt = self._get_xlabel_xt(self.setp['xticks size'], 45)
         offset = mpl.transforms.ScaledTranslation(
-            xt, self._xticklabels_yt, self.figure.dpi_scale_trans)
+            xt, -self._xticklabels_yt/72, self.figure.dpi_scale_trans)
         for i in range(len(year_range)):
             self.xticklabels.append(self.ax0.text(
                 year_range[i], self.setp['ymin'], xlabels[i], rotation=45,


### PR DESCRIPTION
Building on the capabilities that were developed in PR #184 and PR #181, the goal of this PR is to add two graphs: one that shows a barplot of the average yearly water budget and another one that shows the avg. monthly water budget.

![avg_yearly_water_budget](https://user-images.githubusercontent.com/10170372/39050817-c73a649c-4474-11e8-9dbb-6e492957fefe.png)

![avg_monthly_water_budget](https://user-images.githubusercontent.com/10170372/39050908-1d19b28c-4475-11e8-9e68-36d47d5c99e4.png)

![fig_stackmanager_newfig](https://user-images.githubusercontent.com/10170372/39050806-c1768392-4474-11e8-9b3e-1d8eeeb4786d.gif)
