### PR TITLE
PR: Add the capability to export recharge results to csv

### DIFF
--- a/gwhat/common/utils.py
+++ b/gwhat/common/utils.py
@@ -84,14 +84,14 @@ def save_content_to_excel(fname, fcontent):
     root, ext = os.path.splitext(fname)
     if ext == '.xls':
         wb = xlwt.Workbook()
-        ws = wb.add_sheet('Normals')
+        ws = wb.add_sheet('Data')
         for i, row in enumerate(fcontent):
             for j, cell in enumerate(row):
                 ws.write(i, j, cell)
         wb.save(root+'.xls')
     else:
-        with xlsxwriter.Workbook(root+'.xlsx') as wb:
-            ws = wb.add_worksheet('Normals')
+        with xlsxwriter.Workbook(root + '.xlsx') as wb:
+            ws = wb.add_worksheet('Data')
             for i, row in enumerate(fcontent):
                 ws.write_row(i, 0, row)
 

--- a/gwhat/gwrecharge/glue.py
+++ b/gwhat/gwrecharge/glue.py
@@ -69,12 +69,12 @@ class GLUEDataFrameBase(Mapping):
         budget and GLUE uncertainty limits in a single column format for each
         monthly time series, so that it can be easily stored in a csv format.
         """
-        year_range = self.store['monthly budget']['years']
+        year_range = self['monthly budget']['years']
         years = np.repeat(year_range, 12).astype(int)
         months = np.tile(np.arange(12)+1, len(year_range)).astype(int)
 
         variables = ['recharge', 'evapo', 'runoff']
-        glue_limits = self.store['monthly budget']['GLUE limits']
+        glue_limits = self['monthly budget']['GLUE limits']
 
         data_header = ['year', 'month', 'precip']
         data_header2 = ['', '', '']
@@ -84,7 +84,7 @@ class GLUEDataFrameBase(Mapping):
         # Add the years, months and precipitation data.
         data[:, 0] = years
         data[:, 1] = months
-        data[:, 2] = self.store['monthly budget']['precip'].flatten()
+        data[:, 2] = self['monthly budget']['precip'].flatten()
 
         # Add the water budget component monthly values.
         col = 3
@@ -93,8 +93,7 @@ class GLUEDataFrameBase(Mapping):
                 data_header.append(var)
                 data_header3.append('(mm)')
                 data_header2.append('GLUE%02d' % (lim*100))
-                data[:, col] = self.store[
-                    'monthly budget'][var][:, :, i].flatten()
+                data[:, col] = self['monthly budget'][var][:, :, i].flatten()
                 col += 1
         data = np.round(data, 1)
 
@@ -122,11 +121,11 @@ class GLUEDataFrameBase(Mapping):
                  ['', '', 'GLUE05', 'GLUE50', 'GLUE95']]
 
         # Prepare the data.
-        wltime = self.store['water levels']['time']
+        wltime = self['water levels']['time']
         data = np.zeros((len(wltime), 5)) * np.nan
-        data[:, 0] = self.store['water levels']['time']
-        data[:, 1] = self.store['water levels']['observed']
-        data[:, 2:5] = self.store['water levels']['predicted'] / 1000
+        data[:, 0] = self['water levels']['time']
+        data[:, 1] = self['water levels']['observed']
+        data[:, 2:5] = self['water levels']['predicted'] / 1000
         data = np.round(data, 2)
 
         # Merge the data header with the data. Also, convert float nan to text,
@@ -153,16 +152,16 @@ class GLUEDataFrameBase(Mapping):
         keys = ['Well', 'Well ID', 'Province', 'Latitude', 'Longitude',
                 'Elevation', 'Municipality']
         for key in keys:
-            header.append([key, self.store['wlinfo'][key]])
+            header.append([key, self['wlinfo'][key]])
         header.append([''])
 
         # Add the weather station infos.
         header.append(
-            ['Weather Station', self.store['wxinfo']['Station Name']])
+            ['Weather Station', self['wxinfo']['Station Name']])
         keys = ['Climate Identifier', 'Province', 'Latitude',
                 'Longitude', 'Elevation']
         for key in keys:
-            header.append([key, self.store['wxinfo'][key]])
+            header.append([key, self['wxinfo'][key]])
 
         # Add the GWHAT version and date of creation.
         header.extend([

--- a/gwhat/gwrecharge/glue.py
+++ b/gwhat/gwrecharge/glue.py
@@ -12,12 +12,18 @@
 from calendar import monthrange
 from collections.abc import Mapping
 from abc import abstractmethod
+from time import strftime
 
 
 # ---- Third parties imports
 
 import numpy as np
 from xlrd import xldate_as_tuple
+
+# ---- Local imports
+
+from gwhat.common.utils import save_content_to_file
+from gwhat import __namever__
 
 
 class GLUEDataFrameBase(Mapping):
@@ -34,6 +40,138 @@ class GLUEDataFrameBase(Mapping):
     def __load_data__(self, data):
         """Load glue data and save it in a store."""
         pass
+
+    def save_mly_glue_budget_to_file(self, filename):
+        """
+        Save the montlhy water budget results evaluated with GLUE to a file.
+        The extension of the file determine in which file type the data will
+        be saved (xls or xlsx for Excel, csv for coma-separated values text
+        file, or tsv for tab-separated values text file).
+        """
+        fcontent = self._produce_file_header()
+        fcontent.extend(self._format_mly_glue_budget())
+        save_content_to_file(filename, fcontent)
+
+    def save_glue_waterlvl_to_file(self, filename):
+        """
+        Exports the daily water levels predicted with GLUE to file.
+        The extension of the file determine in which file type the data will
+        be saved (xls or xlsx for Excel, csv for coma-separated values text
+        file, or tsv for tab-separated values text file).
+        """
+        fcontent = self._produce_file_header()
+        fcontent.extend(self._format_glue_waterlvl())
+        save_content_to_file(filename, fcontent)
+
+    def _format_mly_glue_budget(self):
+        """
+        Format the montlhy results for each of the component of the water
+        budget and GLUE uncertainty limits in a single column format for each
+        monthly time series, so that it can be easily stored in a csv format.
+        """
+        year_range = self.store['monthly budget']['years']
+        years = np.repeat(year_range, 12).astype(int)
+        months = np.tile(np.arange(12)+1, len(year_range)).astype(int)
+
+        variables = ['recharge', 'evapo', 'runoff']
+        glue_limits = self.store['monthly budget']['GLUE limits']
+
+        data_header = ['year', 'month', 'precip']
+        data_header2 = ['', '', '']
+        data_header3 = ['', '', '(mm)']
+        data = np.zeros((len(years), len(variables)*len(glue_limits)+3))
+
+        # Add the years, months and precipitation data.
+        data[:, 0] = years
+        data[:, 1] = months
+        data[:, 2] = self.store['monthly budget']['precip'].flatten()
+
+        # Add the water budget component monthly values.
+        col = 3
+        for var in variables:
+            for i, lim in enumerate(glue_limits):
+                data_header.append(var)
+                data_header3.append('(mm)')
+                data_header2.append('GLUE%02d' % (lim*100))
+                data[:, col] = self.store[
+                    'monthly budget'][var][:, :, i].flatten()
+                col += 1
+        data = np.round(data, 1)
+
+        # Merge the data header with the data. Also, convert float nan to text,
+        # so that it is possible to save to an Excel file.
+        dataf = [data_header, data_header3, data_header2]
+        if np.isnan(data).any():
+            m, n = np.shape(data)
+            for i in range(m):
+                dataf.append(['nan' if np.isnan(x) else x for x in data[i, :]])
+        else:
+            dataf.extend(data.tolist())
+
+        return dataf
+
+    def _format_glue_waterlvl(self):
+        """
+        Format the water levels predicted with GLUE for the 0.05, 0.5, and
+        0.95 GLUE uncertainty limits. Also add the observed water levels and
+        those predicted with the Master Recession Curve.
+        """
+        # Prepare the data header.
+        dataf = [['Time', 'Obs. WL', 'Pred. WL', 'Pred. WL', 'Pred. WL'],
+                 ['(days)', '(mbgs)', '(mbgs)', '(mbgs)', '(mbgs)'],
+                 ['', '', 'GLUE05', 'GLUE50', 'GLUE95']]
+
+        # Prepare the data.
+        wltime = self.store['water levels']['time']
+        data = np.zeros((len(wltime), 5)) * np.nan
+        data[:, 0] = self.store['water levels']['time']
+        data[:, 1] = self.store['water levels']['observed']
+        data[:, 2:5] = self.store['water levels']['predicted'] / 1000
+        data = np.round(data, 2)
+
+        # Merge the data header with the data. Also, convert float nan to text,
+        # so that it is possible to save to an Excel file.
+
+        if np.isnan(data).any():
+            m, n = np.shape(data)
+            for i in range(m):
+                dataf.append(['nan' if np.isnan(x) else x for x in data[i, :]])
+        else:
+            dataf.extend(data.tolist())
+
+        return dataf
+
+    def _produce_file_header(self):
+        """"
+        Produce a header for saving GLUE results to file. The header contains
+        information about the observation well, the weather station, and the
+        version of GWHAT and creation time of the file.
+        """
+        header = []
+
+        # Add the observation well infos.
+        keys = ['Well', 'Well ID', 'Province', 'Latitude', 'Longitude',
+                'Elevation', 'Municipality']
+        for key in keys:
+            header.append([key, self.store['wlinfo'][key]])
+        header.append([''])
+
+        # Add the weather station infos.
+        header.append(
+            ['Weather Station', self.store['wxinfo']['Station Name']])
+        keys = ['Climate Identifier', 'Province', 'Latitude',
+                'Longitude', 'Elevation']
+        for key in keys:
+            header.append([key, self.store['wxinfo'][key]])
+
+        # Add the GWHAT version and date of creation.
+        header.extend([
+            [''],
+            ['Created by', __namever__],
+            ['Created on', strftime("%d/%m/%Y")],
+            ['']])
+
+        return header
 
 
 class GLUEDataFrame(GLUEDataFrameBase):

--- a/gwhat/gwrecharge/glue.py
+++ b/gwhat/gwrecharge/glue.py
@@ -94,7 +94,6 @@ class GLUEDataFrame(GLUEDataFrameBase):
         # along with the oberved values.
         grp = self.store['water levels'] = {}
         grp['time'] = data['water levels']['time']
-        grp['date'] = data['water levels']['date']
         grp['observed'] = data['water levels']['observed']
         grp['GLUE limits'] = [0.05, 0.5, 0.95]
         grp['predicted'] = calcul_glue(
@@ -110,14 +109,14 @@ def calcul_glue(data, glue_limits, varname='recharge'):
         raise ValueError("varname value must be",
                          ['recharge', 'etr', 'ru', 'hydrograph'])
     x = np.array(data[varname])
-    _, n = np.shape(x)
+    _, ntime = np.shape(x)
 
     rmse = np.array(data['RMSE'])
     # Rescale the RMSE so the sum of all values equal 1.
     rmse = rmse/np.sum(rmse)
 
-    glue = np.zeros((n, len(glue_limits)))
-    for i in range(n):
+    glue = np.zeros((ntime, len(glue_limits)))
+    for i in range(ntime):
         # Sort predicted values.
         isort = np.argsort(x[:, i])
         # Compute the Cumulative Density Function.
@@ -282,6 +281,10 @@ def calcul_hydro_yrly_budget(glue_dly):
 
 if __name__ == '__main__':
     from gwhat.gwrecharge.gwrecharge_calc2 import load_glue_from_npy
-
     GLUE_DATA = load_glue_from_npy('glue_rawdata.npy')
     GLUE_DSET = GLUEDataFrame(GLUE_DATA)
+
+    GLUE_DSET.save_mly_glue_budget_to_file(
+        'C:\\Users\\User\\glue_water_budget.xlsx')
+    GLUE_DSET.save_glue_waterlvl_to_file(
+        'C:\\Users\\User\\glue_water_levels.xlsx')

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -42,6 +42,14 @@ LOCS = ['left', 'top', 'right', 'bottom']
 LANGUAGES = ['French', 'English']
 
 
+# Calcul the time delta between the datum of the matplotlib ax Excel time
+# system.
+
+t1 = xldate_from_date_tuple((2000, 1, 1), 0)  # time in Excel
+t2 = mpl.dates.date2num(datetime.datetime(2000, 1, 1))  # time in mpl format
+DT4XLS2MPL = t2-t1
+
+
 class FigureStackManager(QWidget):
     def __init__(self, parent=None):
         super(FigureStackManager, self).__init__(parent)
@@ -1181,19 +1189,23 @@ class FigWaterLevelGLUE(FigCanvasBase):
         ax.tick_params(axis='y', direction='out', labelsize=12)
         ax.xaxis.set_ticks_position('bottom')
         ax.tick_params(axis='x', direction='out')
-        self.figure.autofmt_xdate()
+
+        xloc = mpl.dates.AutoDateLocator()
+        ax.xaxis.set_major_locator(xloc)
+        xfmt = mpl.dates.AutoDateFormatter(xloc)
+        ax.xaxis.set_major_formatter(xfmt)
 
         # ---- Plot the observed and glue predicted water levels.
 
         wlobs = glue_df['water levels']['observed']
-        dates = strdate_to_datetime(glue_df['water levels']['date'])
+        xlstime = glue_df['water levels']['time'] + DT4XLS2MPL
         wl05 = glue_df['water levels']['predicted'][:, 0]/1000
         wl95 = glue_df['water levels']['predicted'][:, 2]/1000
 
         ax = self.figure.axes[0]
-        ax.plot(dates, wlobs, color='b', ls='None', marker='.', ms=3,
-                zorder=100)
-        ax.fill_between(dates, wl95, wl05, facecolor='0.85', lw=1,
+        ax.plot(xlstime, wlobs, color='b', ls='None',
+                marker='.', ms=3, zorder=100)
+        ax.fill_between(xlstime, wl95, wl05, facecolor='0.85', lw=1,
                         edgecolor='0.65', zorder=0)
 
         self.setup_axes_labels()

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -10,9 +10,11 @@
 
 import os
 import os.path as osp
+import datetime
 
 # ---- Imports: third parties
 
+from xlrd.xldate import xldate_from_date_tuple
 import numpy as np
 import matplotlib as mpl
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
@@ -29,9 +31,6 @@ from PyQt5.QtWidgets import (
 
 # ---- Imports: local
 
-from gwhat.gwrecharge.glue import (
-    calcul_glue, calcul_hydro_yrly_budget)
-from gwhat.gwrecharge.gwrecharge_calc2 import strdate_to_datetime
 from gwhat.common import icons, QToolButtonNormal, QToolButtonSmall
 from gwhat.common.utils import find_unique_filename
 from gwhat.common.widgets import QFrameLayout

--- a/gwhat/utils/math.py
+++ b/gwhat/utils/math.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2014-2018 GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+
+import numpy as np
+import datetime
+
+
+def clip_time_series(tclip, tp, xp):
+    """
+    Clip tp and xp on tclip. tclip and tp must be arrays of numerical
+    Excel times. Return two empty arrays if tclip and tp are
+    mutually exclusive.
+    """
+    # Check that tp and tclip are not mutually exclusive.
+    if len(np.unique(np.hstack([tclip, tp]))) == (len(tclip) + len(tp)):
+        return [], []
+
+    # Clip xp and tp on tclip.
+    if tp[0] < tclip[0]:
+        idx = np.where(tp >= tclip[0])[0][0]
+        tp = tp[idx:]
+        xp = xp[idx:]
+    if tp[-1] > tclip[-1]:
+        idx = np.where(tp <= tclip[-1])[0][-1]
+        tp = tp[:idx+1]
+        xp = xp[:idx+1]
+    return tp, xp
+
+
+def convert_date_to_datetime(years, months, days):
+    """
+    Produce datetime series from years, months, and days series.
+    """
+    dates = [0] * len(years)
+    for t in range(len(years)):
+        dates[t] = datetime.datetime(
+                int(years[t]), int(months[t]), int(days[t]), 0)
+    return dates


### PR DESCRIPTION
Fixes #182

Add a button to the groundwater recharge widget that allows to save GLUE water budget and GLUE water levels results to either an Excel or csv file.

![image](https://user-images.githubusercontent.com/10170372/39268874-1548eea0-489f-11e8-9549-c21cd8310c84.png)

## GLUE monthly water budget

![image](https://user-images.githubusercontent.com/10170372/39268955-48885c74-489f-11e8-827b-5925b1937da6.png)


## GLUE daily water levels

![image](https://user-images.githubusercontent.com/10170372/39269001-643efc16-489f-11e8-90c7-2f558a5d9336.png)

