### PR TITLE
PR: Improve the handling of errors when the importing a dataset and the data file is not formatted correctly.

### DIFF
--- a/docs/manage_data.rst
+++ b/docs/manage_data.rst
@@ -107,10 +107,12 @@ omitted in the time series.
 Water level data files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-GWHAT can read water level data from either coma-separated text files with UTF-8 encoding
-or from an Excel spreadsheet (:file:`xls` or :file:`xlsx`).
+GWHAT can read water level data from either coma-separated text files (:file:`csv`)
+encoded in UTF-8 or from an Excel spreadsheet (:file:`xls` or :file:`xlsx`).
 An example of correctly formatted water level data file is presented in
-:numref:`water_level_datafile_example`.
+:numref:`water_level_datafile_example`. This file is also available in the
+folder of the project example that is distributed with GWHAT 
+(see :numref:`sec_installing_on_windows`).
 
 The file header contains information about the well name, identifier, province,
 latitude, longitude, and elevation. The first column of the data must contain
@@ -118,6 +120,9 @@ the time in excel numeric format. The second column must contain the water level
 given in metres below the ground surface. The third and fourth columns correspond,
 respectively, to the barometric pressure and the Earth tides.
 This will be discussed in more details in :numref:`chap_computing_the_brf`.
+Note that the name of the labels of the header and of the data columns 
+(e.g., Well Name, Well ID, Date) must be respected for the program
+to read the content of the file correctly.
 
 .. _water_level_datafile_example:
 .. figure:: img/files/water_level_datafile.*

--- a/docs/plotting_hydrograph.rst
+++ b/docs/plotting_hydrograph.rst
@@ -5,7 +5,8 @@ Plotting the Hydrographs
 
 This document shows how to produce publication quality figures of well hydrographs
 in GWHAT using the tools available under the tab :guilabel:`Plot Hydrograph` shown
-in :numref:`scs_plot_hydrograph`.
+in :numref:`scs_plot_hydrograph`. For detailed information on how to import the
+weather and water level data in GWHAT, please consult :numref:`chap_importing_data`.
 
 .. _scs_plot_hydrograph:
 .. figure:: img/demo/demo_plot_hydrograph.*
@@ -20,7 +21,8 @@ in :numref:`scs_plot_hydrograph`.
 The tab :guilabel:`Plot Hydrograph` consists mainly of an editor to produce a
 graph showing the groundwater level time series in relation to weather
 conditions. As shown in :numref:`fig_plot_hydrograph_annoted`, the editor
-consists of a toolbar, the panel :guilabel:`Input data`, the panel
+consists of a toolbar, the panel :guilabel:`Input data` 
+(documented in :numref:`chap_importing_data`), the panel
 :guilabel:`Axes settings`, and a canvas where the hydrograph figure is shown.
 
 A figure of the hydrograph is produced as soon as a water level and weather

--- a/gwhat/common/widgets.py
+++ b/gwhat/common/widgets.py
@@ -237,39 +237,6 @@ class QFrameLayout(QFrame):
         return self.layout().columnCount()
 
 
-class QGroupWidget(QGroupBox):
-    def __init__(self, parent=None):
-        super(QGroupWidget, self).__init__(parent)
-
-        col = '#404040'
-        self.setStyleSheet('QGroupBox{'
-                           'font-weight: bold;'
-                           'font-size: 14px;'
-                           'color: %s;'
-                           'border: 1.5px solid %s;'
-                           'border-radius: 5px;'
-                           'subcontrol-position: bottom left;'
-                           'margin-top: 7px;'
-                           '}'
-                           'QGroupBox::title {'
-                           'subcontrol-position: top left;'
-                           'left: 10px; top: -10px;'
-                           'padding: 0 3px 0 3px;'
-                           '}' % (col, col))
-
-        self.setLayout(QGridLayout())
-        self.layout().setContentsMargins(10, 25, 10, 10)  # (l, t, r, b)
-
-    def addWidget(self, item, x, y, nx=1, ny=1):
-        self.layout().addWidget(item, x, y, nx, ny)
-
-    def addLayout(self, layout, x, y, nx=1, ny=1):
-        self.layout().addLayout(layout, x, y, nx, ny)
-
-    def rowCount(self):
-        return self.layout().rowCount()
-
-
 class DialogWindow(QDialog):
 
     def __init__(self, parent=None, resizable=False, maximize=True):

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -620,10 +620,13 @@ class NewDatasetDialog(QDialog):
         for i in range(5):
             QCoreApplication.processEvents()
 
-        if self._datatype == 'water level':
-            self._dataset = wlrd.read_water_level_datafile(filename)
-        elif self._datatype == 'daily weather':
-            self._dataset = wxrd.WXDataFrame(filename)
+        try:
+            if self._datatype == 'water level':
+                self._dataset = wlrd.read_water_level_datafile(filename)
+            elif self._datatype == 'daily weather':
+                self._dataset = wxrd.WXDataFrame(filename)
+        except Exception:
+            self._dataset = None
         QApplication.restoreOverrideCursor()
 
         self.directory.setText(filename)

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -18,7 +18,8 @@ from PyQt5.QtCore import Qt, QCoreApplication, QSize
 from PyQt5.QtCore import pyqtSignal as QSignal
 from PyQt5.QtWidgets import (QWidget, QComboBox, QGridLayout, QTextEdit,
                              QLabel, QMessageBox, QLineEdit, QPushButton,
-                             QFileDialog, QApplication, QDialog, QMenu)
+                             QFileDialog, QApplication, QDialog, QMenu,
+                             QGroupBox)
 
 # ---- Imports: Local Libraries
 
@@ -475,9 +476,9 @@ class NewDatasetDialog(QDialog):
 
         # Info Groubox Layout
 
-        self.grp_info = myqt.QGroupWidget()
-        self.grp_info.setTitle("Dataset info")
+        self.grp_info = QGroupBox("Dataset info :")
         self.grp_info.setEnabled(False)
+        self.grp_info.setLayout(QGridLayout())
         self.grp_info.layout().setColumnStretch(2, 100)
         self.grp_info.layout().setSpacing(10)
 

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -391,16 +391,21 @@ class DataManager(QWidget):
 
 
 class NewDatasetDialog(QDialog):
+    """
+    A dialog window where water level and weather datasets can be imported
+    into the project.
+    """
+
     ConsoleSignal = QSignal(str)
     sig_new_dataset_imported = QSignal(str, object)
+
+    DATATYPES = ['water level', 'daily weather']
 
     def __init__(self, datatype, parent=None, projet=None):
         super(NewDatasetDialog, self).__init__(parent)
 
-        if datatype.lower() not in ['water level', 'daily weather']:
-            print("ERROR: datatype value must be :",
-                  ['water level', 'daily weather'])
-            raise ValueError
+        if datatype.lower() not in self.DATATYPES:
+            raise ValueError("datatype value must be :", self.DATATYPES)
         self._datatype = datatype.lower()
 
         self.setWindowTitle('Import Dataset: %s' % datatype.title())
@@ -612,8 +617,8 @@ class NewDatasetDialog(QDialog):
             self.load_dataset(filename)
 
     def load_dataset(self, filename):
-        """Loads the dataset and displays the information in the UI."""
-        if not os.path.exists(filename):
+        """Load the dataset and display the information in the UI."""
+        if not osp.exists(filename):
             print('Path does not exist. Cannot open %s.' % filename)
             return
 

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -708,6 +708,7 @@ class NewDatasetDialog(QDialog):
     def close(self):
         super(NewDatasetDialog, self).close()
         self.clear()
+        self._msg.setVisible(False)
 
     def clear(self, clear_directory=True):
         if clear_directory:

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -431,11 +431,17 @@ class NewDatasetDialog(QDialog):
         self.btn_browse.setToolTip('Select a datafile...')
         self.btn_browse.clicked.connect(self.select_dataset)
 
-        msg = ('<font color=red size=2><i>Error : %s data file is '
-               'not formatted correctly.</i></font>'
-               ) % self._datatype.capitalize()
+        url_i = "https://gwhat.readthedocs.io/en/latest/manage_data.html"
+        msg = ("<font color=red size=2><i>"
+               "The %s data file is not formatted correctly.<br>"
+               "Please consult the <a href=\"%s\">documentation</a>"
+               " for detailed information<br>"
+               "on how to format your input data files correctly."
+               "</i></font>"
+               ) % (self._datatype.capitalize(), url_i)
         self._msg = QLabel(msg)
         self._msg.setVisible(False)
+        self._msg.setOpenExternalLinks(True)
 
         # Select Dataset Layout
 

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -496,6 +496,7 @@ class NewDatasetDialog(QDialog):
         # ----- Toolbar
 
         self._dset_name = QLineEdit()
+        self._dset_name.setEnabled(False)
 
         self.btn_ok = QPushButton('Import')
         self.btn_ok.setMinimumWidth(100)
@@ -625,19 +626,21 @@ class NewDatasetDialog(QDialog):
             self._dataset = wxrd.WXDataFrame(filename)
         QApplication.restoreOverrideCursor()
 
-        # Update the GUI :
-
         self.directory.setText(filename)
+        self.update_gui_with_dset_infos()
+
+    def update_gui_with_dset_infos(self):
+        """
+        Display the values store in the dataset. Disable the UI and write
+        an error message if the dataset is None.
+        """
+        self._msg.setVisible(self._dataset is None)
+        self.btn_ok.setEnabled(self._dataset is not None)
+        self.grp_info.setEnabled(self._dataset is not None)
+        self._dset_name.setEnabled(self._dataset is not None)
         if self._dataset is None:
-            self._msg.setVisible(True)
-            self.btn_ok.setEnabled(False)
-            self.grp_info.setEnabled(False)
             self.clear(clear_directory=False)
         else:
-            self.grp_info.setEnabled(True)
-            self._msg.setVisible(False)
-            self.btn_ok.setEnabled(True)
-
             if self._datatype == 'water level':
                 self._stn_name.setText(self._dataset['Well'])
                 self._sid.setText(self._dataset['Well ID'])

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -797,8 +797,7 @@ class ExportWeatherButton(QToolButtonBase):
 if __name__ == '__main__':
     from reader_projet import ProjetReader
     import sys
-    projet = ProjetReader("C:/Users/jsgosselin/GWHAT/gwhat/"
-                          "tests/@ new-prô'jèt!/@ new-prô'jèt!.gwt")
+    projet = ProjetReader("C:/Users/User/gwhat/Projects/Example/Example.gwt")
 
     app = QApplication(sys.argv)
 

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -49,7 +49,6 @@ def read_water_level_datafile(filename):
     elif ext in ['.xls', '.xlsx']:
         with xlrd.open_workbook(filename, on_demand=True) as wb:
             sheet = wb.sheet_by_index(0)
-
             data = [sheet.row_values(rowx, start_colx=0, end_colx=None) for
                     rowx in range(sheet.nrows)]
 
@@ -58,8 +57,11 @@ def read_water_level_datafile(filename):
     for row, line in enumerate(data):
         if len(line) == 0:
             continue
+        try:
+            label = line[0].lower().replace(":", "").replace("=", "").strip()
+        except AttributeError:
+            continue
 
-        label = line[0].lower().replace(":", "").replace("=", "").strip()
         if label == 'well name':
             df['Well'] = str(line[1])
         elif label == 'well id':

--- a/gwhat/tests/test_manager_data.py
+++ b/gwhat/tests/test_manager_data.py
@@ -155,6 +155,13 @@ def test_delete_waterlevel_data(data_manager_bot, mocker):
     data_manager, qtbot = data_manager_bot
     data_manager.show()
 
+    # Mock the QMessageBox to return No, try to delete the dataset and assert
+    # that the dataset was not removed from the project.
+    mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.No)
+    qtbot.mouseClick(data_manager.btn_del_wldset, Qt.LeftButton)
+    assert data_manager.wldataset_count() == 1
+    assert data_manager.wldsets_cbox.currentText() == "PO01 - Calixa-Lavallée"
+
     # Mock the QMessageBox to return Yes, delete the waterlevel dataset, and
     # assert that it was removed from the project.
     mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)


### PR DESCRIPTION
Fixes #191 

- [x] Add a link to the documentation in the error message.
- [x] Enclose the loading of data files in a `try` block to prevent any crash when loading a dataset.
- [x] Make the UI consistent with the rest of GWHAT main application.
- [x] Update de documentation

![image](https://user-images.githubusercontent.com/10170372/39310385-40f1d884-4938-11e8-8a2f-c03f96ae6cab.png)