### PR TITLE
PR: Refactor the update manager to lower the fail rates on the CI servers.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,8 @@ coverage:
   
   status:
     project: yes
+      default:
+        threshold: 1%
     patch: no
     changes: no
     

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,7 @@ coverage:
   range: "70...100"
   
   status:
-    project: yes
+    project:
       default:
         threshold: 1%
     patch: no

--- a/gwhat/widgets/updates.py
+++ b/gwhat/widgets/updates.py
@@ -155,7 +155,8 @@ class WorkerUpdates(QObject):
             self.error = ('Unable to retrieve information because the'
                           ' connection timed out.')
         except Exception:
-            self.error = ('Unable to check for updates.')
+            self.error = ('Unable to check for updates because of'
+                          ' an unexpected error.')
         self.sig_ready.emit()
 
 

--- a/gwhat/widgets/updates.py
+++ b/gwhat/widgets/updates.py
@@ -23,7 +23,6 @@
 # ---- Imports: standard libraries
 
 import re
-from urllib.error import URLError, HTTPError
 from distutils.version import LooseVersion
 
 
@@ -146,11 +145,15 @@ class WorkerUpdates(QObject):
 
             result = check_update_available(version, releases)
             self.update_available, self.latest_release = result
-        except HTTPError:
-            self.error = ('Unable to retrieve information.')
-        except URLError:
-            self.error = ('Unable to connect to the internet. <br><br>Make '
+        except requests.exceptions.HTTPError:
+            self.error = ('Unable to retrieve information because of.'
+                          ' an http error.')
+        except requests.exceptions.ConnectionError:
+            self.error = ('Unable to connect to the internet.<br><br>Make '
                           'sure the connection is working properly.')
+        except requests.exceptions.Timeout:
+            self.error = ('Unable to retrieve information because the'
+                          ' connection timed out.')
         except Exception:
             self.error = ('Unable to check for updates.')
         self.sig_ready.emit()

--- a/gwhat/widgets/updates.py
+++ b/gwhat/widgets/updates.py
@@ -72,6 +72,7 @@ class ManagerUpdates(QMessageBox):
         self.start_updates_check()
 
     def start_updates_check(self):
+        """Check if updates are available."""
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         self.thread_updates.start()
 
@@ -118,9 +119,6 @@ class ManagerUpdates(QMessageBox):
 class WorkerUpdates(QObject):
     """
     Worker that checks for releases using the Github API.
-
-    Copyright (c) Spyder Project Contributors
-    Licensed under the terms of the MIT License
     """
     sig_ready = QSignal()
 
@@ -141,9 +139,7 @@ class WorkerUpdates(QObject):
             releases = [item['tag_name'].replace('gwhat-', '')
                         for item in data
                         if item['tag_name'].startswith("gwhat")]
-            version = __version__
-
-            result = check_update_available(version, releases)
+            result = check_update_available(__version__, releases)
             self.update_available, self.latest_release = result
         except requests.exceptions.HTTPError:
             self.error = ('Unable to retrieve information because of.'
@@ -231,7 +227,7 @@ def is_stable_version(version):
     Stable version example: 1.2, 1.3.4, 1.0.5
     Not stable version: 1.2alpha, 1.3.4beta, 0.1.0rc1, 3.0.0dev
 
-    Copyright (c) Spyder Project Contributors
+    Copyright (c) 2017 Spyder Project Contributors
     Licensed under the terms of the MIT License
     """
     if not isinstance(version, tuple):


### PR DESCRIPTION
The test on the CI servers for the `ManagerUpdates` are failing a lot.

The objective here is to see if it is possible to make it pass more often by using the `requests` package. This will also make the code simpler and more robust.