### PR TITLE
PR: Prevent the use of some special characters in the dataset names

### DIFF
--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -28,6 +28,7 @@ from gwhat.common import icons
 import gwhat.common.widgets as myqt
 from gwhat.hydrograph4 import LatLong2Dist
 import gwhat.projet.reader_waterlvl as wlrd
+from gwhat.projet.reader_projet import INVALID_CHARS
 import gwhat.meteo.weather_reader as wxrd
 from gwhat.meteo.weather_reader import WXDataFrameBase
 

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -672,6 +672,13 @@ class NewDatasetDialog(QDialog):
                 self._lon.setValue(self._dataset['Longitude'])
                 self._alt.setValue(self._dataset['Elevation'])
                 self._dset_name.setText(self._dataset['Station Name'])
+    def _dsetname_isvalid(self):
+        """
+        Check if the dataset name respect the established guidelines to avoid
+        problem with the hdf5 format.
+        """
+        return (self.name != '' and
+                not any(char in self.name for char in INVALID_CHARS))
 
     def accept_dataset(self):
         """Accept and emit the dataset."""

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -293,7 +293,7 @@ class DataManager(QWidget):
 
     def new_wxdset_imported(self, name, dataset):
         """
-        Receives the new weather dataset, saves it in the project and
+        Receive the new weather dataset, save it in the project and
         update the GUI.
         """
         print("Saving the new weather dataset in the project.", end=" ")
@@ -717,6 +717,7 @@ class NewDatasetDialog(QDialog):
     # ---- Display Handlers
 
     def close(self):
+        """Qt method override."""
         super(NewDatasetDialog, self).close()
         self.clear()
         self._msg.setVisible(False)

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -73,7 +73,7 @@ class DataManager(QWidget):
         self.wldsets_cbox.currentIndexChanged.connect(self.wldset_changed)
 
         self.btn_load_wl = QToolButtonSmall(icons.get_icon('importFile'))
-        self.btn_load_wl.setToolTip('Import a new WL dataset...')
+        self.btn_load_wl.setToolTip('Import a new water level dataset...')
         self.btn_load_wl.clicked.connect(self.import_wldataset)
 
         self.btn_del_wldset = QToolButtonSmall(icons.get_icon('clear'))

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -216,7 +216,7 @@ class DataManager(QWidget):
         """
         print("Saving the new water level dataset in the project...", end=" ")
         self.projet.add_wldset(name, dataset)
-        self.update_wldsets()
+        self.update_wldsets(name)
         self.update_wldset_info()
         self.wldset_changed()
         print("done")
@@ -298,7 +298,7 @@ class DataManager(QWidget):
         """
         print("Saving the new weather dataset in the project.", end=" ")
         self.projet.add_wxdset(name, dataset)
-        self.update_wxdsets()
+        self.update_wxdsets(name)
         self.update_wxdset_info()
         self.wxdset_changed()
         print("done")

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -682,8 +682,14 @@ class NewDatasetDialog(QDialog):
 
     def accept_dataset(self):
         """Accept and emit the dataset."""
-        if self.name == '':
-            msg = 'Please enter a valid name for the dataset.'
+        if not self._dsetname_isvalid():
+            msg = ('''
+                   <p>Please enter a valid name for the dataset.<\p>
+                   <p>A dataset name must be at least one charater long
+                   and can't contain any of the following special
+                   characters:<\p>
+                   <center>\ / : * ? " < > |<\center>
+                   ''')
             btn = QMessageBox.Ok
             QMessageBox.warning(self, 'Save dataset', msg, btn)
             return

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -739,6 +739,7 @@ class NewDatasetDialog(QDialog):
         self._dataset['Longitude'] = self.longitude
         self._dataset['Elevation'] = self.altitude
 
+        self.hide()
         self.sig_new_dataset_imported.emit(self.name, self._dataset)
         self.close()
 

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -24,6 +24,8 @@ import numpy as np
 from gwhat.meteo.weather_reader import WXDataFrameBase
 from gwhat.gwrecharge.glue import GLUEDataFrameBase
 
+INVALID_CHARS = ['\\', '/', ':', '*', '?', '"', '<', '>', '|']
+
 
 class ProjetReader(object):
     def __init__(self, filename):


### PR DESCRIPTION
Fixes #192

When clicking on the `Import` button, a warning message is now shown to the user if invalid characters are present in the name of the dataset.

Also, GWHAT switch to the newly imported dataset automatically now.

![image](https://user-images.githubusercontent.com/10170372/39475532-8406163e-4d26-11e8-9215-75e5e9535bed.png)
