### PR TITLE
PR: Correct the calculation of GLUE by correcting the definition of the likelihood function.

### DIFF
--- a/gwhat/gwrecharge/glue.py
+++ b/gwhat/gwrecharge/glue.py
@@ -248,7 +248,7 @@ def calcul_glue(data, glue_limits, varname='recharge'):
     x = np.array(data[varname])
     _, ntime = np.shape(x)
 
-    rmse = np.array(data['RMSE'])
+    rmse = 1/np.array(data['RMSE'])
     # Rescale the RMSE so the sum of all values equal 1.
     rmse = rmse/np.sum(rmse)
 


### PR DESCRIPTION
From Beven and Binley, 1992 regarding the informal LIKELIHOOD FUNCTIONS:

> It should be zero for all simulations that are considered to exhibit behaviour dissimilar to the system under study, and it should increase monotonically as the similarity in behaviour increases.

By mistake, the RMSE was used directly as the likelihood function instead of the inverse of the RMSE. This caused the simulations that are considered to exhibit behaviour dissimilar to the system to have more weight than those that exhibit behaviour more similar to the system.

The impact on the estimated values of groundwater recharge should be minimal though because all behavioural models produced for the evaluation of groundwater recharge had a RMSE quite similar in all cases, since all the "bad" models were discarded a-priori.


