### PR TITLE
PR: Use text instead of icons to label the tabs of the tab widget in which the tools to analyse the hydrograph are displayed and add tooltips.

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -375,17 +375,24 @@ class WLCalc(myqt.DialogWindow):
         self.widget_MRCparam.setSpacing(5)
         self.widget_MRCparam.setColumnStretch(2, 500)
 
-        # -------------------------------------------------- Tool Tab Area ----
+        # ---- Tool Tab Area
 
         tooltab = QTabWidget()
-        tooltab.setIconSize(QSize(28, 28))
-        tooltab.setTabPosition(tooltab.North)
+        tooltab.addTab(self.widget_MRCparam, 'MRC')
+        tooltab.setTabToolTip(
+            0, ("<p>A tool to evaluate the master recession curve"
+                " of the hydrograph.</p>"))
+        tooltab.addTab(self.rechg_eval_widget, 'Recharge')
+        tooltab.setTabToolTip(
+            1, ("<p>A tool to evaluate groundwater recharge and its"
+                " uncertainty from observed water levels and daily "
+                " weather data.</p>"))
+        tooltab.addTab(self.config_brf, 'BRF')
+        tooltab.setTabToolTip(
+            2, ("<p>A tool to evaluate the barometric response function of"
+                " the well.</p>"))
 
-        tooltab.addTab(self.widget_MRCparam, icons.get_icon('MRCalc'), '')
-        tooltab.addTab(self.rechg_eval_widget, icons.get_icon('recharge'), '')
-        tooltab.addTab(self.config_brf, icons.get_icon('setup'), '')
-
-        # ---------------------------------------------------- Right Panel ----
+        # ---- Right Panel
 
         self.right_panel = myqt.QFrameLayout()
 


### PR DESCRIPTION
Unfortunately, the icons look great but they do not help very much to tell a new user what each tab is about. So I think it is better and cleaner to simply use text. Especially since there was not a dedicated icon for the BRF yet.

Also, this new layout takes up less vertical space, so this is a step forward in fixing #152.

Finallly, I added a tool-tip for each tab that describes a little better what each tool is.

## Now
![image](https://user-images.githubusercontent.com/10170372/45056668-98ff8900-b061-11e8-9713-20322e56406a.png)


## Before
![image](https://user-images.githubusercontent.com/10170372/45056716-b2083a00-b061-11e8-87e4-57842d35c5f8.png)



