### PR TITLE
PR: Plot the recession in the hydrograph editor

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -20,6 +20,7 @@ import datetime
 import numpy as np
 from PyQt5.QtCore import Qt
 from PyQt5.QtCore import pyqtSlot as QSlot
+from PyQt5.QtCore import pyqtSignal as QSignal
 from PyQt5.QtWidgets import (QGridLayout, QComboBox, QTextEdit,
                              QSizePolicy, QPushButton, QLabel, QTabWidget,
                              QApplication, QWidget)
@@ -53,6 +54,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
     i.e. display the data as a continuous line or individual dot, perform a
     MRC and ultimately estimate groundwater recharge.
     """
+    sig_new_mrc = QSignal()
 
     def __init__(self, datamanager, parent=None):
         DialogWindow.__init__(self, parent, maximize=True)
@@ -495,6 +497,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.wldset.set_mrc(A, B, self.peak_indx, self.time, hp)
         self.btn_save_mrc.setEnabled(True)
         self.draw_mrc()
+        self.sig_new_mrc.emit()
 
         QApplication.restoreOverrideCursor()
 

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -511,7 +511,7 @@ class HydroprintGUI(myqt.DialogWindow):
         if sender == self.btn_language:
             self.hydrograph.draw_ylabels()
             self.hydrograph.setup_xticklabels()
-            self.hydrograph.set_legend()
+            self.hydrograph.setup_legend()
         elif sender in [self.waterlvl_max, self.waterlvl_scale]:
             self.hydrograph.setup_waterlvl_scale()
             self.hydrograph.draw_ylabels()
@@ -553,7 +553,7 @@ class HydroprintGUI(myqt.DialogWindow):
             #                   set_time_scale()
             #                   draw_figure_title
             self.hydrograph.draw_waterlvl()
-            self.hydrograph.set_legend()
+            self.hydrograph.setup_legend()
         elif sender == self.qweather_bin:
             self.hydrograph.resample_bin()
             self.hydrograph.draw_weather()

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -484,6 +484,16 @@ class HydroprintGUI(myqt.DialogWindow):
             self.date_start_widget.setDate(QDate(date0[0], date0[1], date0[2]))
             self.date_end_widget.setDate(QDate(date1[0], date1[1], date1[2]))
 
+    @QSlot()
+    def mrc_wl_changed(self):
+        """
+        Force a redraw of the MRC water levels after the results have
+        changed for the dataset.
+        """
+        self.hydrograph.draw_mrc_wl()
+        self.hydrograph.setup_legend()
+        self.hydrograph_scrollarea.load_mpl_figure(self.hydrograph)
+
     @QSlot(GLUEDataFrameBase)
     def glue_wl_changed(self, gluedf):
         """

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -622,6 +622,7 @@ class HydroprintGUI(myqt.DialogWindow):
         self.hydrograph.isGraphTitle = self.page_setup_win.isGraphTitle
         self.hydrograph.set_meteo_on(self.page_setup_win.is_meteo_on)
         self.hydrograph.set_glue_wl_on(self.page_setup_win.is_glue_wl_on)
+        self.hydrograph.set_mrc_wl_on(self.page_setup_win.is_mrc_wl_on)
 
         # Weather bins :
 
@@ -743,12 +744,14 @@ class HydroprintGUI(myqt.DialogWindow):
         self.page_setup_win.isTrendLine = layout['trend_line']
         self.page_setup_win.is_meteo_on = layout['meteo_on']
         self.page_setup_win.is_glue_wl_on = layout['glue_wl_on']
+        self.page_setup_win.is_mrc_wl_on = layout['mrc_wl_on']
 
         self.page_setup_win.legend_on.set_value(layout['legend_on'])
         self.page_setup_win.title_on.set_value(layout['title_on'])
         self.page_setup_win.wltrend_on.set_value(layout['trend_line'])
         self.page_setup_win.meteo_on.set_value(layout['meteo_on'])
         self.page_setup_win.glue_wl_on.set_value(layout['glue_wl_on'])
+        self.page_setup_win.mrc_wl_on.set_value(layout['mrc_wl_on'])
 
         self.page_setup_win.fwidth.setValue(layout['fwidth'])
         self.page_setup_win.fheight.setValue(layout['fheight'])
@@ -820,6 +823,7 @@ class HydroprintGUI(myqt.DialogWindow):
         layout['trend_line'] = bool(self.page_setup_win.isTrendLine)
         layout['meteo_on'] = bool(self.page_setup_win.is_meteo_on)
         layout['glue_wl_on'] = bool(self.page_setup_win.is_glue_wl_on)
+        layout['mrc_wl_on'] = bool(self.page_setup_win.is_mrc_wl_on)
 
         # Save the colors :
 
@@ -856,6 +860,7 @@ class PageSetupWin(QWidget):
         self.isTrendLine = False
         self.is_meteo_on = True
         self.is_glue_wl_on = False
+        self.is_mrc_wl_on = False
         self.va_ratio = 0.2
 
         self.__initUI__()
@@ -944,12 +949,13 @@ class PageSetupWin(QWidget):
         self.wltrend_on = OnOffToggleWidget('Water Level Trend', False)
         self.meteo_on = OnOffToggleWidget('Weather Data', True)
         self.glue_wl_on = OnOffToggleWidget('GLUE Water Levels', False)
+        self.mrc_wl_on = OnOffToggleWidget('MRC Water Levels', False)
 
         grpbox = QGroupBox("Graph Components Visibility :")
         layout = QGridLayout(grpbox)
         for i, widget in enumerate([self.legend_on, self.title_on,
                                     self.wltrend_on, self.meteo_on,
-                                    self.glue_wl_on]):
+                                    self.glue_wl_on, self.mrc_wl_on]):
             layout.addWidget(widget, i, 0)
         layout.setContentsMargins(10, 10, 10, 10)
 
@@ -970,6 +976,7 @@ class PageSetupWin(QWidget):
         self.isTrendLine = self.wltrend_on.value()
         self.is_meteo_on = self.meteo_on.value()
         self.is_glue_wl_on = self.glue_wl_on.value()
+        self.is_mrc_wl_on = self.mrc_wl_on.value()
         self.va_ratio = self.va_ratio_spinBox.value()
 
         self.newPageSetupSent.emit(True)
@@ -992,6 +999,7 @@ class PageSetupWin(QWidget):
         self.wltrend_on.set_value(self.isTrendLine)
         self.meteo_on.set_value(self.is_meteo_on)
         self.glue_wl_on.set_value(self.is_glue_wl_on)
+        self.mrc_wl_on.set_value(self.is_mrc_wl_on)
 
     def show(self):
         super(PageSetupWin, self).show()

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -201,7 +201,8 @@ class Hydrograph(Figure):
     @property
     def mrc_wl_on(self):
         """Return whether the mrc water levels must be plotted or not."""
-        return self.__mrc_wl_on
+        return (self.__mrc_wl_on and self.wldset is not None and
+                self.wldset.mrc_exists())
 
     @mrc_wl_on.setter
     def mrc_wl_on(self, x):

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -199,7 +199,7 @@ class Hydrograph(Figure):
         self.glue_wl_on = x
         if self.__isHydrographExists:
             self.draw_glue_wl()
-            self.set_legend()
+            self.setup_legend()
 
     @property
     def language(self):
@@ -228,7 +228,7 @@ class Hydrograph(Figure):
         """Set the namespace for the GLUE dataframe."""
         self.gluedf = gluedf
         self.draw_glue_wl()
-        self.set_legend()
+        self.setup_legend()
 
     def clf(self, *args, **kargs):
         """Matplotlib override to set internal flag."""
@@ -473,13 +473,13 @@ class Hydrograph(Figure):
 
         # --------------------------------------------------------- LEGEND ----
 
-        self.set_legend()
+        self.setup_legend()
 
         # ---------------------------------------------------- UPDATE FLAG ----
 
         self.__isHydrographExists = True
 
-    def set_legend(self):
+    def setup_legend(self):
         """Setup the legend of the graph."""
         if self.isLegend == 1:
             labelDB = LabelDatabase(self.language).legend
@@ -556,7 +556,7 @@ class Hydrograph(Figure):
         self.l2_ax2.set_color(self.colorsDB.rgb['WL data'])
         self.h_WLmes.set_color(self.colorsDB.rgb['WL obs'])
         self.draw_weather()
-        self.set_legend()
+        self.setup_legend()
 
     def update_fig_size(self):
         """Update the size of the figure."""

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -128,14 +128,11 @@ class Hydrograph(Figure):
         #             smooth the water level data
         self.meteo_on = True
         self.glue_wl_on = False
+        self.mrc_wl_on = False
         self.gridLines = 2  # 0 -> None, 1 -> "-" 2 -> ":"
         self.datemode = 'Month'  # 'month' or 'year'
         self.label_font_size = 14
         self.date_labels_pattern = 2
-
-        # plot or not the estimated recession segment that
-        # were used to estimate the MRC
-        self.isMRC = False
 
         # Waterlvl & Meteo Obj :
 
@@ -202,6 +199,23 @@ class Hydrograph(Figure):
             self.setup_legend()
 
     @property
+    def mrc_wl_on(self):
+        """Return whether the mrc water levels must be plotted or not."""
+        return self.__mrc_wl_on
+
+    @mrc_wl_on.setter
+    def mrc_wl_on(self, x):
+        """Set whether the mrc water levels data must plotted or not."""
+        self.__mrc_wl_on = bool(x)
+
+    def set_mrc_wl_on(self, x):
+        """Set whether the mrc water levels data must plotted or not."""
+        self.mrc_wl_on = x
+        if self.__isHydrographExists:
+            self.draw_mrc_wl()
+            self.setup_legend()
+
+    @property
     def language(self):
         return self.__language
 
@@ -228,6 +242,12 @@ class Hydrograph(Figure):
         """Set the namespace for the GLUE dataframe."""
         self.gluedf = gluedf
         self.draw_glue_wl()
+        self.setup_legend()
+
+    def set_mrcdf(self, mrcdf):
+        """Set the namespace for the MRC dataframe."""
+        self.mrcdf = mrcdf
+        self.draw_mrc_wl()
         self.setup_legend()
 
     def clf(self, *args, **kargs):
@@ -392,7 +412,7 @@ class Hydrograph(Figure):
             mec=self.colorsDB.rgb['WL obs'])
 
         # Predicted Recession Curves
-        self.plot_recess, = self.ax2.plot(
+        self._mrc_plt, = self.ax2.plot(
             [], [], color='red', lw=1.5, dashes=[5, 3], zorder=100,
             alpha=0.85)
 
@@ -401,6 +421,7 @@ class Hydrograph(Figure):
 
         self.draw_waterlvl()
         self.draw_glue_wl()
+        self.draw_mrc_wl()
 
         # ---- Init weather artists
 
@@ -524,9 +545,9 @@ class Hydrograph(Figure):
                 lg_handles.append(self.h_WLmes)
                 lg_labels.append(labelDB[7])
 
-            if self.isMRC:
+            if self.mrc_wl_on:
                 lg_labels.append(labelDB[8])
-                lg_handles.append(self.plot_recess)
+                lg_handles.append(self._mrc_plt)
 
             if self.glue_wl_on:
                 lg_labels.append('GLUE 5/95')
@@ -818,13 +839,16 @@ class Hydrograph(Figure):
             xlstime, wl95, wl05, facecolor='0.85', lw=1, edgecolor='0.65',
             zorder=0)
 
-    def draw_recession(self):
-        t = self.WaterLvlObj.trecess
-        wl = self.WaterLvlObj.hrecess
-        self.plot_recess.set_data(t, wl)
+    def draw_mrc_wl(self):
+        """Draw the water levels predicted with the MRC."""
+        if self.mrc_wl_on is False:
+            self._mrc_plt.set_visible(False)
+            return
+        else:
+            self._mrc_plt.set_visible(True)
 
-        self.isMRC = True
-        self.set_legend()
+        self._mrc_plt.set_data(
+            self.wldset['mrc/time'], self.wldset['mrc/recess'])
 
     def draw_waterlvl(self):
         """
@@ -1325,7 +1349,7 @@ if __name__ == '__main__':
 #        hg.best_fit_time(waterLvlObj.time)
 #        hg.generate_hydrograph(meteo_obj)
 #
-#        hg.draw_recession()
+#        hg.draw_mrc_wl()
 #        hg.savefig(dirname + '/MRC_hydrograph.pdf')
 #
 #        hg.isMRC = False
@@ -1360,7 +1384,7 @@ if __name__ == '__main__':
 ##        ax2.plot(wl2.time, wl2.lvl, color='green')
 #
 #        hg.draw_GLUE()
-#        hg.draw_recession()
+#        hg.draw_mrc_wl()
 #        hg.savefig(dirname + '/GLUE_hydrograph.pdf', dpi=300)
 #
     # ---- Show figure on-screen

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -838,12 +838,10 @@ class Hydrograph(Figure):
         """Draw the water levels predicted with the MRC."""
         if self.mrc_wl_on is False:
             self._mrc_plt.set_visible(False)
-            return
         else:
             self._mrc_plt.set_visible(True)
-
-        self._mrc_plt.set_data(
-            self.wldset['mrc/time'], self.wldset['mrc/recess'])
+            self._mrc_plt.set_data(
+                self.wldset['mrc/time'], self.wldset['mrc/recess'])
 
     def draw_waterlvl(self):
         """

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -244,12 +244,6 @@ class Hydrograph(Figure):
         self.draw_glue_wl()
         self.setup_legend()
 
-    def set_mrcdf(self, mrcdf):
-        """Set the namespace for the MRC dataframe."""
-        self.mrcdf = mrcdf
-        self.draw_mrc_wl()
-        self.setup_legend()
-
     def clf(self, *args, **kargs):
         """Matplotlib override to set internal flag."""
         self.__isHydrographExists = False

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -141,6 +141,8 @@ class MainWindow(QMainWindow):
 
         splash.showMessage("Initializing analyse hydrograph...")
         self.tab_hydrocalc = HydroCalc.WLCalc(self.dmanager)
+        self.tab_hydrocalc.sig_new_mrc.connect(
+            self.tab_hydrograph.mrc_wl_changed)
         self.tab_hydrocalc.rechg_eval_widget.sig_new_gluedf.connect(
             self.tab_hydrograph.glue_wl_changed)
 

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -607,6 +607,9 @@ class WLDataFrameHDF5(dict):
         if 'glue_wl_on' not in layout.keys():
             # Added in version 0.3.2 (see PR #202)
             layout['glue_wl_on'] = False
+        if 'mrc_wl_on' not in layout.keys():
+            # Added in version 0.3.3 (see PR #225)
+            layout['mrc_wl_on'] = False
 
         return layout
 

--- a/gwhat/tests/test_dwnld_weather_data.py
+++ b/gwhat/tests/test_dwnld_weather_data.py
@@ -282,7 +282,7 @@ def test_download_data(downloader_bot, mocker):
 
     # Download the data for the selected stations.
     process_finished = wxdata_downloader.sig_download_process_ended
-    with qtbot.waitSignal(process_finished, raising=True, timeout=100000):
+    with qtbot.waitSignal(process_finished, raising=True, timeout=300000):
         qtbot.mouseClick(wxdata_downloader.btn_get, Qt.LeftButton)
 
     # Assert that data before 2000 were not downloaded


### PR DESCRIPTION
Fixes #214

Similarly to the GLUE predicted water levels (see PR #202), the idea of this PR is to add the capability to plot the recession results on the hydrograph.

![image](https://user-images.githubusercontent.com/10170372/40279209-6fe5ce98-5c0c-11e8-92aa-ba46479836d6.png)
