### PR TITLE
PR: Fix DeprecationWarning: invalid escape sequence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
 
 install:
   - python -m pip install -r requirements-dev.txt
+  - python -m pip install pytest-ordering==0.5.*
   - sudo apt-get install cython3
   - sudo apt-get install libhdf5-dev
   - python setup.py build_ext --inplace

--- a/gwhat/meteo/dwnld_weather_data.py
+++ b/gwhat/meteo/dwnld_weather_data.py
@@ -623,8 +623,8 @@ class DwnldWeatherWidget(QWidget):
         min_year = cdf['Minimum Year']
         max_year = cdf['Maximum Year']
 
-        fields = ['T<sub>max<\sub>', 'T<sub>min<\sub>', 'T<sub>mean<\sub>',
-                  'P<sub>tot<\sub>']
+        fields = ['T<sub>max</sub>', 'T<sub>min</sub>', 'T<sub>mean</sub>',
+                  'P<sub>tot</sub>']
 
         html = """
                <p align="center">

--- a/gwhat/meteo/gapfill_weather_postprocess.py
+++ b/gwhat/meteo/gapfill_weather_postprocess.py
@@ -468,7 +468,7 @@ def plot_gamma_dist(Ymes, Ypre, fname, language='English'):
         if label >= 1:
             ylabels.append('%d' % label)
         elif label <= 10**-3:
-            ylabels.append('$\mathdefault{10^{%d}}$' % np.log10(label))
+            ylabels.append('$\\mathdefault{10^{%d}}$' % np.log10(label))
         else:
             ylabels.append(str(label))
     ax0.set_yticklabels(ylabels)

--- a/gwhat/meteo/weather_viewer.py
+++ b/gwhat/meteo/weather_viewer.py
@@ -943,7 +943,7 @@ if __name__ == '__main__':
     app.setFont(ft)
 
     fmeteo = ("..\\..\\Projects\\Example\\Meteo\\Output\\"
-              "MARIEVILLE (7024627)\MARIEVILLE (7024627)_1980-2017.out")
+              "MARIEVILLE (7024627)\\MARIEVILLE (7024627)_1980-2017.out")
     wxdset = WXDataFrame(fmeteo)
 
     w = WeatherViewer()

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -204,7 +204,7 @@ class ProjetReader(object):
         Add the water level dataset to the project hdf5 file.
 
         A dataset name must be at least one charater long and can't contain
-        any of the following special characters: \ / : * ? " < > |
+        any of the following special characters: \\ / : * ? " < > |
         """
         if not is_dsetname_valid(name):
             raise ValueError("The name of the dataset is not valid.")
@@ -290,7 +290,7 @@ class ProjetReader(object):
         Add the weather dataset to the project hdf5 file.
 
         A dataset name must be at least one charater long and can't contain
-        any of the following special characters: \ / : * ? " < > |
+        any of the following special characters: \\ / : * ? " < > |
         """
         if not is_dsetname_valid(name):
             raise ValueError("The name of the dataset is not valid.")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ pytest-qt
 pytest-xvfb
 pytest-mock
 pytest-cov
-pytest-ordering==0.5.*
+pytest-ordering
 flaky
 codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ pytest-qt
 pytest-xvfb
 pytest-mock
 pytest-cov
-pytest-ordering
+pytest-ordering==0.5.*
 flaky
 codecov


### PR DESCRIPTION
Replaced all invalid single `\` by `\\` where needed in the code to prevent the warning.