### PR TITLE
PR: Add the option to delete all BRF results at once for a given dataset

### DIFF
--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -462,6 +462,11 @@ class BRFViewer(QWidget):
         self.btn_del.setToolTip('Delete current BRF results')
         self.btn_del.clicked.connect(self.del_brf)
 
+        self.btn_del_all = QToolButtonNormal(icons.get_icon('close_all'))
+        self.btn_del_all.setToolTip(
+            'Delete all BRF results for the current water level dataset.')
+        self.btn_del_all.clicked.connect(self.del_all_brf)
+
         self.btn_save = btn_save = QToolButtonNormal(icons.get_icon('save'))
         btn_save.setToolTip('Save current BRF graph...')
         btn_save.clicked.connect(self.select_savefig_path)
@@ -474,9 +479,9 @@ class BRFViewer(QWidget):
 
         self.tbar = myqt.QFrameLayout()
 
-        buttons = [btn_save, self.btn_del, VSep(), self.btn_prev,
-                   self.current_brf, self.total_brf, self.btn_next, VSep(),
-                   self.btn_setp, self.btn_language]
+        buttons = [btn_save, self.btn_del,  self.btn_del_all, VSep(),
+                   self.btn_prev, self.current_brf, self.total_brf,
+                   self.btn_next, VSep(), self.btn_setp, self.btn_language]
 
         for btn in buttons:
             if isinstance(btn, QLayout):

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -555,6 +555,21 @@ class BRFViewer(QWidget):
         self.wldset.del_brf(name)
         self.update_brfnavigate_state()
 
+    def del_all_brf(self):
+        """Delete all the graphs and BRF results for the current dataset."""
+        msg = ("Do you want to delete all BRF results that were evaluated "
+               "for dataset <i>{}</i>?"
+               "<br><br>"
+               "All data will be lost permanently."
+               ).format(self.wldset.name)
+        btn = QMessageBox.Yes | QMessageBox.No
+        reply = QMessageBox.question(self, 'Delete all BRF results', msg, btn)
+
+        if reply == QMessageBox.Yes:
+            for name in self.wldset.saved_brf():
+                self.wldset.del_brf(name)
+            self.update_brfnavigate_state()
+
     def new_brf_added(self):
         self.current_brf.setMaximum(self.wldset.brf_count())
         self.current_brf.setValue(self.wldset.brf_count())

--- a/gwhat/brf_mod/tests/test_brf_mod.py
+++ b/gwhat/brf_mod/tests/test_brf_mod.py
@@ -222,6 +222,31 @@ def test_del_brf_result(brfmanager, wldataset, mocker, qtbot):
     assert brfmanager.viewer.tbar.isEnabled() is False
 
 
+@pytest.mark.skipif(os.name == 'posix',
+                    reason="This feature is not supported on Linux")
+def test_del_all_brf_result(brfmanager, wldataset, mocker, qtbot):
+    """Test that the BRF results are deleted correctly."""
+    brfmanager.show()
+    brfmanager.set_wldset(wldataset)
+
+    # Create BRF results X2.
+    assert brfmanager.viewer.current_brf.value() == 0
+    brfmanager.calc_brf()
+    brfmanager.calc_brf()
+    assert brfmanager.viewer.current_brf.value() == 2
+
+    # Click to delete all BRF results, but answer No.
+    mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.No)
+    qtbot.mouseClick(brfmanager.viewer.btn_del_all, Qt.LeftButton)
+    assert brfmanager.viewer.current_brf.value() == 2
+
+    # Click to delete all BRF results and answer Yes.
+    mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
+    qtbot.mouseClick(brfmanager.viewer.btn_del_all, Qt.LeftButton)
+    assert brfmanager.viewer.current_brf.value() == 0
+    assert brfmanager.viewer.tbar.isEnabled() is False
+
+
 if __name__ == "__main__":
     pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])
     # pytest.main()

--- a/gwhat/tests/pytest_test_order.txt
+++ b/gwhat/tests/pytest_test_order.txt
@@ -7,7 +7,6 @@
  7 - test_manager_data.py
  8 - test_hydroprint.py
  9 - test_hydrocalc.py
-10 - test_brf_mod.py
 11 - test_mainwindow.py
 
 test_tabwidget.py


### PR DESCRIPTION
Fixes #233

- [x] Add a button to delete all BRF results at once for the current dataset
- [x] Add a test to cover this new feature

![image](https://user-images.githubusercontent.com/10170372/50306872-a6038500-0464-11e9-96e0-533276cd75d0.png)
