### PR TITLE
PR: Fix missing hidden imports for PyInstaller packaging

### DIFF
--- a/gwhat/meteo/tests/test_dwnld_weather_data.py
+++ b/gwhat/meteo/tests/test_dwnld_weather_data.py
@@ -29,7 +29,7 @@ DATADIR = os.path.join(osp.dirname(osp.realpath(__file__)), "data")
 STATIONDB = os.path.join(DATADIR, "Station Inventory EN.csv")
 STATIONLIST = os.path.join(DATADIR, "weather_station_list.lst")
 
-gwhat.meteo.search_weather_data.URL_TOR = urljoin(
+gwhat.meteo.weather_station_finder.URL_TOR = urljoin(
     'file:', pathname2url(STATIONDB))
 
 

--- a/releases/gwhat.spec
+++ b/releases/gwhat.spec
@@ -10,11 +10,15 @@ added_files = [('../gwhat/ressources/splash.png', 'ressources'),
                ('../gwhat/ressources/icons_png/*.png', 'ressources/icons_png')
                ]
 
+HIDDENIMPORTS = ['h5py.defs', 'h5py.utils', 'h5py.h5ac', 'h5py._proxy',
+                 'scipy.stats._continuous_distns', 'scipy._lib.messagestream',
+                 'numpy.core._dtype_ctypes']
+
 a = Analysis(['../gwhat/mainwindow.py'],
              pathex=['C:\\Program Files (x86)\\Windows Kits\\10\\Redist\\ucrt\\DLLs\\x64'],
              binaries=[],
              datas=added_files ,
-             hiddenimports=['h5py.defs', 'h5py.utils', 'h5py.h5ac', 'h5py._proxy', 'scipy.stats._continuous_distns', 'scipy._lib.messagestream'],
+             hiddenimports=HIDDENIMPORTS,
              hookspath=[],
              runtime_hooks=[],
              excludes=['PySide', 'PyQt4'],


### PR DESCRIPTION
This is a follow up of PR #249.

When trying to start GWHAT with the package generated by PyInstaller, we get the following error traceback:

```python
Starting GWHAT...
Traceback (most recent call last):
  File "gwhat\mainwindow.py", line 20, in <module>
  File "C:\Python36-x64\lib\site-packages\PyInstaller\loader\pyimod03_importers.py", line 627, in exec_module
  File "site-packages\matplotlib\__init__.py", line 141, in <module>
  File "C:\Python36-x64\lib\site-packages\PyInstaller\loader\pyimod03_importers.py", line 627, in exec_module
  File "site-packages\matplotlib\cbook\__init__.py", line 33, in <module>
  File "C:\Python36-x64\lib\site-packages\PyInstaller\loader\pyimod03_importers.py", line 627, in exec_module
  File "site-packages\numpy\__init__.py", line 151, in <module>
  File "C:\Python36-x64\lib\site-packages\PyInstaller\loader\pyimod03_importers.py", line 627, in exec_module
  File "site-packages\numpy\ctypeslib.py", line 369, in <module>
  File "site-packages\numpy\ctypeslib.py", line 358, in _get_typecodes
  File "site-packages\numpy\ctypeslib.py", line 358, in <dictcomp>
ModuleNotFoundError: No module named 'numpy.core._dtype_ctypes'
[18312] Failed to execute script mainwindow
```