### PR TITLE
PR: Fix numpy.linalg.lstsq warning about new default for rcond parameter

### DIFF
--- a/gwhat/meteo/gapfill_weather_algorithm2.py
+++ b/gwhat/meteo/gapfill_weather_algorithm2.py
@@ -1068,7 +1068,7 @@ class GapFillWeather(QObject):
             # A = results.params
 
             # Using Numpy function:
-            A = np.linalg.lstsq(X, Y)[0]
+            A = np.linalg.lstsq(X, Y, rcond=None)[0]
 
         else:  # Least Absolute Deviations regression
 
@@ -1832,7 +1832,7 @@ def L1LinearRegression(X, Y):
     n, m = np.shape(X)
 
     # Initialize with least-squares fit.
-    B = np.linalg.lstsq(X, Y)[0]
+    B = np.linalg.lstsq(X, Y, rcond=None)[0]
     BOld = np.copy(B)
 
     # Force divergence.
@@ -1854,7 +1854,7 @@ def L1LinearRegression(X, Y):
         Xb = np.tile(weight, (m, 1)).transpose() * X
         Yb = weight * Y
 
-        B = np.linalg.lstsq(Xb, Yb)[0]
+        B = np.linalg.lstsq(Xb, Yb, rcond=None)[0]
 
     return B
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ xlsxwriter
 xlrd
 xlwt
 cython>=0.25.2
+numpy>1.14
 scipy
 matplotlib>=2.0.2
 requests


### PR DESCRIPTION
Since numpy v0.14.0, the following was issued each time numpy.linalg.lstsq was used in GWHAT:

```python
gwhat/meteo/tests/test_gapfill_weather_algorithm.py::test_fill_data
  C:\projects\gwhat\gwhat\meteo\gapfill_weather_algorithm2.py:1857: FutureWarning: `rcond` parameter will change to the default of machine precision times ``max(M, N)`` where M and N are the input matrix dimensions.
  To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`.
    B = np.linalg.lstsq(Xb, Yb)[0]
```
So to avoid this warning, we simply had to set `rcond=None` explicitly when using `lstsq`. The new default is better, precision wise, than the older one.

Se the documentation for more details:
https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.linalg.lstsq.html