### PR TITLE
PR: Add Cython compilation directive to pyx for language_level=3

### DIFF
--- a/gwhat/gwrecharge/gwrecharge_calculs.pyx
+++ b/gwhat/gwrecharge/gwrecharge_calculs.pyx
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+#cython: language_level=3
 
 # Copyright © 2014-2018 GWHAT Project Contributors
 # https://github.com/jnsebgosselin/gwhat


### PR DESCRIPTION
Add Cython compilation directive to *.pyx to avoid language_level FutureWarning. 