### PR TITLE
PR: Fix UserWarning matplotlib: The 'normed' kwarg is deprecated

### DIFF
--- a/gwhat/meteo/gapfill_weather_postprocess.py
+++ b/gwhat/meteo/gapfill_weather_postprocess.py
@@ -420,7 +420,7 @@ def plot_gamma_dist(Ymes, Ypre, fname, language='English'):
 
     # Histogram
 
-    ax0.hist(Ymes, bins=20, color=c1, histtype='stepfilled', normed=True,
+    ax0.hist(Ymes, bins=20, color=c1, histtype='stepfilled', density=True,
              alpha=0.25, ec=c1, label=lg_labels[0])
 
     # Measured Gamma PDF


### PR DESCRIPTION
UserWarning matplotlib: The 'normed' kwarg is deprecated

As per the matploblib documentation (https://matplotlib.org/api/_as_gen/matplotlib.pyplot.hist.html), the normed keyword is deprecated and the density keyword argument should be used instead.