### PR TITLE
PR: Change the icon of the tool to delete data in the water level and weather dataset manager

### DIFF
--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -87,7 +87,7 @@ class DataManager(QWidget):
         self.btn_load_wl.setToolTip('Import a new water level dataset...')
         self.btn_load_wl.clicked.connect(self.import_wldataset)
 
-        self.btn_del_wldset = QToolButtonSmall(icons.get_icon('clear'))
+        self.btn_del_wldset = QToolButtonSmall('delete_data')
         self.btn_del_wldset.setToolTip('Delete current dataset.')
         self.btn_del_wldset.clicked.connect(self.del_current_wldset)
 
@@ -124,7 +124,7 @@ class DataManager(QWidget):
         self.btn_load_meteo.setToolTip('Import a new weather dataset...')
         self.btn_load_meteo.clicked.connect(self.import_wxdataset)
 
-        self.btn_del_wxdset = QToolButtonSmall(icons.get_icon('clear'))
+        self.btn_del_wxdset = QToolButtonSmall('delete_data')
         self.btn_del_wxdset.setToolTip('Delete current dataset.')
         self.btn_del_wxdset.clicked.connect(self.del_current_wxdset)
 

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -7,21 +7,18 @@
 # Licensed under the terms of the GNU General Public License.
 
 
-# ---- Imports: Standard Libraries
-
+# ---- Standard Library imports
 import os
 import os.path as osp
 
-# ---- Import: Third Party Libraries
-
-from PyQt5.QtCore import Qt, QCoreApplication, QSize
+# ---- Third party imports
+from PyQt5.QtCore import Qt, QCoreApplication
 from PyQt5.QtCore import pyqtSignal as QSignal
 from PyQt5.QtWidgets import (QWidget, QComboBox, QGridLayout, QLabel,
                              QMessageBox, QLineEdit, QPushButton,
                              QFileDialog, QApplication, QDialog, QGroupBox)
 
 # ---- Local library imports
-
 from gwhat.meteo.weather_viewer import WeatherViewer, ExportWeatherButton
 from gwhat.utils.icons import QToolButtonSmall
 from gwhat.utils import icons

--- a/gwhat/utils/icons.py
+++ b/gwhat/utils/icons.py
@@ -114,7 +114,6 @@ FA_ICONS = {
         {'color': COLOR, 'scale_factor': 1.4}],
     }
 
-
 ICON_SIZES = {'large': (32, 32),
               'normal': (28, 28),
               'small': (20, 20)}

--- a/gwhat/utils/icons.py
+++ b/gwhat/utils/icons.py
@@ -109,6 +109,9 @@ FA_ICONS = {
                      {'scale_factor': 0.6,
                       'offset': (0.3, 0.3),
                       'color': COLOR}]}],
+    'delete_data': [
+        ('mdi.delete-forever',),
+        {'color': COLOR, 'scale_factor': 1.4}],
     }
 
 


### PR DESCRIPTION
The `x` icon is used more for removing than deleting, so the new icon is better UX, and we still have the `x` within the trash can that conveys that the dataset is also removed from the manager.

The new icon used is from the `Material and Design`(https://cdn.materialdesignicons.com/3.0.39/_  icon set, which is now available through the `qtawesome` package.

![image](https://user-images.githubusercontent.com/10170372/52223075-ea12e380-2872-11e9-83ca-21416d7577d0.png)
