### PR TITLE
PR: Add an option to mute the confirmation dialog when deleting a dataset

### DIFF
--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -96,16 +96,15 @@ class MainWindow(QMainWindow):
         self.projectfile = self.whatPref.projectfile
         self.projectdir = osp.dirname(self.projectfile)
 
-        # Setup the project and data managers :
-
+        # Setup the project and data managers.
         splash.showMessage("Initializing project and data managers...")
         self.pmanager = ProjetManager(self)
         self.pmanager.currentProjetChanged.connect(self.new_project_loaded)
         self.dmanager = DataManager(parent=self, pm=self.pmanager)
         self.dmanager.setMaximumWidth(250)
+        self.dmanager.sig_new_console_msg.connect(self.write2console)
 
-        # Generate the GUI :
-
+        # Generate the GUI.
         self.__initUI__()
         splash.finish(self)
         self.showMaximized()

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -36,6 +36,7 @@ class DataManager(QWidget):
     wldsetChanged = QSignal(object)
     wxdsetChanged = QSignal(object)
     sig_workdir_changed = QSignal(str)
+    sig_new_console_msg = QSignal(str)
 
     def __init__(self, parent=None, projet=None, pm=None, pytesting=False):
         super(DataManager, self).__init__(parent)

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -215,7 +215,7 @@ class DataManager(QWidget):
             "Delete {} dataset '{}'".format(dsettype, dsetname),
             ("Do you want to delete the {} dataset <i>{}</i>?<br><br>"
              "All data will be deleted from the project, but the "
-             "original data files will be preserved.<br><br>"
+             "original data files will be preserved.<br>"
              ).format(dsettype, dsetname),
             buttons=QMessageBox.Yes | QMessageBox.Cancel,
             parent=self)

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -202,8 +202,28 @@ class DataManager(QWidget):
         btn = QMessageBox.Ok
         QMessageBox.warning(self, 'Warning', msg, btn)
 
-    # ---- WL Dataset
+    def confirm_del_dataset(self, dsetname, dsettype):
+        """
+        Show a message box asking the user confirmation before deleting
+        a dataset. Return the user's answer and whether the
+        'do not show this message again' checkbox has been checked or not.
+        """
+        msg_box = QMessageBox(
+            QMessageBox.Question,
+            "Delete {} dataset '{}'".format(dsettype, dsetname),
+            ("Do you want to delete the {} dataset <i>{}</i>?<br><br>"
+             "All data will be deleted from the project, but the "
+             "original data files will be preserved.<br><br>"
+             ).format(dsettype, dsetname),
+            buttons=QMessageBox.Yes | QMessageBox.Cancel,
+            parent=self)
+        checkbox = QCheckBox("Don't show this message again.")
+        msg_box.setCheckBox(checkbox)
 
+        reply = msg_box.exec_()
+        return reply, not checkbox.isChecked()
+
+    # ---- WL Dataset
     @property
     def wldsets(self):
         """Return a list of all the wldset saved in the project."""

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -14,9 +14,9 @@ import os.path as osp
 # ---- Third party imports
 from PyQt5.QtCore import Qt, QCoreApplication
 from PyQt5.QtCore import pyqtSignal as QSignal
-from PyQt5.QtWidgets import (QWidget, QComboBox, QGridLayout, QLabel,
-                             QMessageBox, QLineEdit, QPushButton,
-                             QFileDialog, QApplication, QDialog, QGroupBox)
+from PyQt5.QtWidgets import (
+    QWidget, QCheckBox, QComboBox, QGridLayout, QLabel, QMessageBox,
+    QLineEdit, QPushButton, QFileDialog, QApplication, QDialog, QGroupBox)
 
 # ---- Local library imports
 from gwhat.meteo.weather_viewer import WeatherViewer, ExportWeatherButton

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -41,6 +41,7 @@ class DataManager(QWidget):
         super(DataManager, self).__init__(parent)
         self._pytesting = pytesting
         self._projet = projet
+        self._confirm_before_deleting_dset = True
 
         self.setWindowFlags(Qt.Window)
         self.setWindowIcon(icons.get_icon('master'))

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -374,20 +374,18 @@ class DataManager(QWidget):
     def del_current_wxdset(self):
         """Delete the currently selected weather dataset."""
         if self.wxdsets_cbox.count() > 0:
-            name = self.wxdsets_cbox.currentText()
-            msg = ('Do you want to delete the weather dataset <i>%s</i>?'
-                   '<br><br>'
-                   'All data will be deleted from the project database, '
-                   'but the original data files will be preserved') % name
-            reply = QMessageBox.question(
-                self, 'Delete current dataset', msg,
-                QMessageBox.Yes | QMessageBox.No)
-
-            if reply == QMessageBox.Yes:
-                self.projet.del_wxdset(name)
-                self.update_wxdsets()
-                self.update_wxdset_info()
-                self.wxdset_changed()
+            dsetname = self.wxdsets_cbox.currentText()
+            if self._confirm_before_deleting_dset:
+                reply, dont_show_again = self.confirm_del_dataset(
+                    dsetname, 'weather')
+                if reply == QMessageBox.Cancel:
+                    return
+                elif reply == QMessageBox.Yes:
+                    self._confirm_before_deleting_dset = dont_show_again
+            self.projet.del_wxdset(dsetname)
+            self.update_wxdsets()
+            self.update_wxdset_info()
+            self.wxdset_changed()
 
     def get_current_wxdset(self):
         """Return the currently selected weather dataset dataframe."""

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -296,25 +296,20 @@ class DataManager(QWidget):
     def del_current_wldset(self):
         """Delete the currently selected water level dataset."""
         if self.wldsets_cbox.count() > 0:
-            name = self.wldsets_cbox.currentText()
-            msg = ('Do you want to delete the dataset <i>%s</i>?'
-                   '<br><br>'
-                   'All data will be deleted from the project database, '
-                   'but the original data files will be preserved') % name
-            reply = QMessageBox.question(
-                self, 'Delete current dataset', msg,
-                QMessageBox.Yes | QMessageBox.No)
-
-            if reply == QMessageBox.No:
-                return
-
-            self.projet.del_wldset(name)
+            dsetname = self.wldsets_cbox.currentText()
+            if self._confirm_before_deleting_dset:
+                reply, dont_show_again = self.confirm_del_dataset(
+                    dsetname, 'water level')
+                if reply == QMessageBox.Cancel:
+                    return
+                elif reply == QMessageBox.Yes:
+                    self._confirm_before_deleting_dset = dont_show_again
+            self.projet.del_wldset(dsetname)
             self.update_wldsets()
             self.update_wldset_info()
             self.wldset_changed()
 
     # ---- WX Dataset
-
     @property
     def wxdsets(self):
         """Return a list of all the weather datasets saved in the project."""

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -264,7 +264,9 @@ class ProjetReader(object):
         return WLDataFrameHDF5(grp)
 
     def del_wldset(self, name):
+        """Delete the specified water level dataset."""
         del self.db['wldsets/%s' % name]
+        self.db.flush()
 
     # ---- Weather Dataset Handlers
 
@@ -339,7 +341,9 @@ class ProjetReader(object):
         self.db.flush()
 
     def del_wxdset(self, name):
+        """Delete the specified weather dataset."""
         del self.db['wxdsets/%s' % name]
+        self.db.flush()
 
 
 class WLDataFrameHDF5(dict):

--- a/gwhat/projet/tests/test_manager_data.py
+++ b/gwhat/projet/tests/test_manager_data.py
@@ -94,14 +94,16 @@ def test_delete_weather_data(datamanager, mocker, qtbot):
     # 'Don't show this message again' option and answer Yes.
     mock_exec_.return_value = QMessageBox.Yes
     mocker.patch.object(QCheckBox, 'isChecked', return_value=True)
-    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True,
+                          timeout=3000):
         qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
     assert datamanager.wxdataset_count() == 1
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
 
     # Click to delete the current weather dataset.
-    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True,
+                          timeout=3000):
         qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
     assert datamanager.wxdataset_count() == 0
     assert datamanager._confirm_before_deleting_dset is False
@@ -159,14 +161,16 @@ def test_delete_waterlevel_data(datamanager, mocker, qtbot):
     # 'Don't show this message again' option and answer Yes.
     mock_exec_.return_value = QMessageBox.Yes
     mocker.patch.object(QCheckBox, 'isChecked', return_value=True)
-    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True,
+                          timeout=3000):
         qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
     assert datamanager.wldataset_count() == 1
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
 
     # Click to delete the current weather dataset.
-    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True,
+                          timeout=3000):
         qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
     assert datamanager.wldataset_count() == 0
     assert datamanager._confirm_before_deleting_dset is False

--- a/gwhat/projet/tests/test_manager_data.py
+++ b/gwhat/projet/tests/test_manager_data.py
@@ -94,13 +94,15 @@ def test_delete_weather_data(datamanager, mocker, qtbot):
     # 'Don't show this message again' option and answer Yes.
     mock_exec_.return_value = QMessageBox.Yes
     mocker.patch.object(QCheckBox, 'isChecked', return_value=True)
-    qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+        qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
     assert datamanager.wxdataset_count() == 1
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
 
     # Click to delete the current weather dataset.
-    qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+        qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
     assert datamanager.wxdataset_count() == 0
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
@@ -157,13 +159,15 @@ def test_delete_waterlevel_data(datamanager, mocker, qtbot):
     # 'Don't show this message again' option and answer Yes.
     mock_exec_.return_value = QMessageBox.Yes
     mocker.patch.object(QCheckBox, 'isChecked', return_value=True)
-    qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+        qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
     assert datamanager.wldataset_count() == 1
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
 
     # Click to delete the current weather dataset.
-    qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+        qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
     assert datamanager.wldataset_count() == 0
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2

--- a/gwhat/projet/tests/test_manager_data.py
+++ b/gwhat/projet/tests/test_manager_data.py
@@ -94,17 +94,13 @@ def test_delete_weather_data(datamanager, mocker, qtbot):
     # 'Don't show this message again' option and answer Yes.
     mock_exec_.return_value = QMessageBox.Yes
     mocker.patch.object(QCheckBox, 'isChecked', return_value=True)
-    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True,
-                          timeout=3000):
-        qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
+    qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
     assert datamanager.wxdataset_count() == 1
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
 
     # Click to delete the current weather dataset.
-    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True,
-                          timeout=3000):
-        qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
+    qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
     assert datamanager.wxdataset_count() == 0
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
@@ -161,17 +157,13 @@ def test_delete_waterlevel_data(datamanager, mocker, qtbot):
     # 'Don't show this message again' option and answer Yes.
     mock_exec_.return_value = QMessageBox.Yes
     mocker.patch.object(QCheckBox, 'isChecked', return_value=True)
-    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True,
-                          timeout=3000):
-        qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
+    qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
     assert datamanager.wldataset_count() == 1
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
 
     # Click to delete the current weather dataset.
-    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True,
-                          timeout=3000):
-        qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
+    qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
     assert datamanager.wldataset_count() == 0
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2


### PR DESCRIPTION
Each time the user wants to delete a water level or weather dataset from the project, a confirmation dialog pops up. This PR adds a checkbox to the dialog that can be checked before accepting the deletion so that the dialog is not shown again over the course of the current session.

- [x] Added a 'Don't show this message again' checkbox to the confirmation dialog that is shown when deleting a dataset.
- [x] Added a log message when a dataset is deleted sucessfully
- [x] Made the deleting process of dataset from project more robust.
- [x] Code refactoring.
- [x] Changed the tests to cover this new feature.

![del_data](https://user-images.githubusercontent.com/10170372/52365785-3fd3c100-2a16-11e9-9833-47cc481aef8a.gif)
