### PR TITLE
PR: Send message to console when deleting a dataset

### DIFF
--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -309,6 +309,9 @@ class DataManager(QWidget):
             self.update_wldsets()
             self.update_wldset_info()
             self.wldset_changed()
+            self.sig_new_console_msg.emit((
+                "<font color=black>Water level dataset <i>{}</i> deleted "
+                "successfully.</font>").format(dsetname))
 
     # ---- WX Dataset
     @property
@@ -387,6 +390,9 @@ class DataManager(QWidget):
             self.update_wxdsets()
             self.update_wxdset_info()
             self.wxdset_changed()
+            self.sig_new_console_msg.emit((
+                "<font color=black>Weather dataset <i>{}</i> deleted "
+                "successfully.</font>").format(dsetname))
 
     def get_current_wxdset(self):
         """Return the currently selected weather dataset dataframe."""

--- a/gwhat/projet/tests/test_manager_data.py
+++ b/gwhat/projet/tests/test_manager_data.py
@@ -94,13 +94,15 @@ def test_delete_weather_data(datamanager, mocker, qtbot):
     # 'Don't show this message again' option and answer Yes.
     mock_exec_.return_value = QMessageBox.Yes
     mocker.patch.object(QCheckBox, 'isChecked', return_value=True)
-    qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+        qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
     assert datamanager.wxdataset_count() == 1
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
 
     # Click to delete the current weather dataset.
-    qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+        qtbot.mouseClick(datamanager.btn_del_wxdset, Qt.LeftButton)
     assert datamanager.wxdataset_count() == 0
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
@@ -157,13 +159,15 @@ def test_delete_waterlevel_data(datamanager, mocker, qtbot):
     # 'Don't show this message again' option and answer Yes.
     mock_exec_.return_value = QMessageBox.Yes
     mocker.patch.object(QCheckBox, 'isChecked', return_value=True)
-    qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+        qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
     assert datamanager.wldataset_count() == 1
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2
 
     # Click to delete the current weather dataset.
-    qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
+    with qtbot.waitSignal(datamanager.sig_new_console_msg, raising=True):
+        qtbot.mouseClick(datamanager.btn_del_wldset, Qt.LeftButton)
     assert datamanager.wldataset_count() == 0
     assert datamanager._confirm_before_deleting_dset is False
     assert mock_exec_.call_count == 2


### PR DESCRIPTION
This is a follow-up to PR #258 to send a message to the console when a water level or weather dataset is deleted.