### PR TITLE
PR: Add the possibility to quickly check/uncheck the Earth tides correction option in the BRF tool

### DIFF
--- a/gwhat/brf_mod/__init__.py
+++ b/gwhat/brf_mod/__init__.py
@@ -11,5 +11,5 @@ from gwhat import __rootdir__
 __install_dir__ = os.path.join(__rootdir__, 'brf_mod')
 
 from gwhat.brf_mod.kgs_brf import (produce_BRFInputtxt, produce_par_file,
-                                   run_kgsbrf, read_BRFOutput)
+                                   run_kgsbrf, read_brf_output)
 from gwhat.brf_mod.kgs_gui import BRFManager

--- a/gwhat/brf_mod/kgs_brf.py
+++ b/gwhat/brf_mod/kgs_brf.py
@@ -137,8 +137,11 @@ def read_brf_output():
             dataf[-1].extend([float(i) for i in row[0].split()])
             count = 1
 
-    dataf = np.array(dataf)
+    # Remove non valid data.
+    dataf = [row for row in dataf if row[4] > -999]
 
+    # Format data into numpy arrays
+    dataf = np.array(dataf)
     lag = dataf[:, 1]
     A = dataf[:, 4]
     err = dataf[:, 5]

--- a/gwhat/brf_mod/kgs_brf.py
+++ b/gwhat/brf_mod/kgs_brf.py
@@ -104,6 +104,10 @@ def run_kgsbrf():
 
 
 def read_BRFOutput():
+    """
+    Read the barometric response function from the output file produced
+    by kgs_brf.exe.
+    """
     filename = os.path.join(__install_dir__, 'BRFOutput.txt')
     with open(filename, 'r') as f:
         reader = list(csv.reader(f))

--- a/gwhat/brf_mod/kgs_brf.py
+++ b/gwhat/brf_mod/kgs_brf.py
@@ -58,7 +58,7 @@ def produce_BRFInputtxt(well, time, wl, bp, et):
     bp = bp * 3.28084
     t = time - time[0]
     fcontent.extend([[time[i], wl[i], bp[i], et[i]] for i in range(N)])
-    
+
     filename = os.path.join(__install_dir__, 'BRFInput.txt')
     with open(filename, 'w', encoding='utf8') as f:
         writer = writer = csv.writer(f, delimiter='\t', lineterminator='\n')

--- a/gwhat/brf_mod/kgs_brf.py
+++ b/gwhat/brf_mod/kgs_brf.py
@@ -65,11 +65,16 @@ def produce_BRFInputtxt(well, time, wl, bp, et):
         writer.writerows(fcontent)
 
 
-def produce_par_file(lagBP, lagET, detrend, correct):
+def produce_par_file(lagBP, correct_earthtides=True,
+                     detrend_waterlevels=True, correct_waterlevels=True):
     brfinput = os.path.join(__install_dir__, 'BRFInput.txt')
     brfoutput = os.path.join(__install_dir__, 'BRFOutput.txt')
     wlcinput = os.path.join(__install_dir__, 'WLCInput.txt')
     wlcoutput = os.path.join(__install_dir__, 'WLCOutput.txt')
+
+    lagET = lagBP if correct_earthtides else -1
+    detrend = 'Yes' if detrend_waterlevels else 'No'
+    correct = 'Yes' if correct_waterlevels else 'No'
 
     par = []
     par.append(['BRF Option (C[ompute] or R[ead]): Compute'])

--- a/gwhat/brf_mod/kgs_brf.py
+++ b/gwhat/brf_mod/kgs_brf.py
@@ -103,7 +103,8 @@ def run_kgsbrf():
             os.system('""%s" < "%s""' % (exename, parname))
 
 
-def read_BRFOutput():
+
+def read_brf_output():
     """
     Read the barometric response function from the output file produced
     by kgs_brf.exe.

--- a/gwhat/brf_mod/kgs_brf.py
+++ b/gwhat/brf_mod/kgs_brf.py
@@ -7,18 +7,15 @@
 # Licensed under the terms of the GNU General Public License.
 
 # ---- Standard library imports
-
 import os
 import csv
 import sys
 
 # ---- Third party imports
-
 import numpy as np
 from xlrd import xldate_as_tuple
 
 # ---- Local imports
-
 from gwhat.brf_mod import __install_dir__
 
 

--- a/gwhat/brf_mod/kgs_brf.py
+++ b/gwhat/brf_mod/kgs_brf.py
@@ -67,6 +67,9 @@ def produce_BRFInputtxt(well, time, wl, bp, et):
 
 def produce_par_file(lagBP, correct_earthtides=True,
                      detrend_waterlevels=True, correct_waterlevels=True):
+    """
+    Create the parameter file requires by the KGS_BRF program.
+    """
     brfinput = os.path.join(__install_dir__, 'BRFInput.txt')
     brfoutput = os.path.join(__install_dir__, 'BRFOutput.txt')
     wlcinput = os.path.join(__install_dir__, 'WLCInput.txt')

--- a/gwhat/brf_mod/kgs_brf.py
+++ b/gwhat/brf_mod/kgs_brf.py
@@ -65,8 +65,8 @@ def produce_BRFInputtxt(well, time, wl, bp, et):
         writer.writerows(fcontent)
 
 
-def produce_par_file(lagBP, correct_earthtides=True,
-                     detrend_waterlevels=True, correct_waterlevels=True):
+def produce_par_file(lagBP, lagET, detrend_waterlevels=True,
+                     correct_waterlevels=True):
     """
     Create the parameter file requires by the KGS_BRF program.
     """
@@ -75,7 +75,6 @@ def produce_par_file(lagBP, correct_earthtides=True,
     wlcinput = os.path.join(__install_dir__, 'WLCInput.txt')
     wlcoutput = os.path.join(__install_dir__, 'WLCOutput.txt')
 
-    lagET = lagBP if correct_earthtides else -1
     detrend = 'Yes' if detrend_waterlevels else 'No'
     correct = 'Yes' if correct_waterlevels else 'No'
 

--- a/gwhat/brf_mod/kgs_brf.py
+++ b/gwhat/brf_mod/kgs_brf.py
@@ -53,13 +53,12 @@ def produce_BRFInputtxt(well, time, wl, bp, et):
     fcontent.append(['Number of Data: %d' % N])
     fcontent.append(['Time WL BP ET'])
 
-    wl = (100-wl)*3.28084
-    bp = bp*3.28084
-    t = time-time[0]
-
-    for i in range(N):
-        fcontent.append([time[i], wl[i], bp[i], et[i]])
-
+    # Add the data to the file content.
+    wl = (100 - wl) * 3.28084
+    bp = bp * 3.28084
+    t = time - time[0]
+    fcontent.extend([[time[i], wl[i], bp[i], et[i]] for i in range(N)])
+    
     filename = os.path.join(__install_dir__, 'BRFInput.txt')
     with open(filename, 'w', encoding='utf8') as f:
         writer = writer = csv.writer(f, delimiter='\t', lineterminator='\n')

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -170,9 +170,6 @@ class BRFManager(myqt.QFrameLayout):
         self.btn_seldata.setToolTip("Select a BRF calculation period with "
                                     "the mouse cursor on the graph.")
 
-        self._correct = QCheckBox('Correct WL')
-        self._correct.setEnabled(False)
-
         # ---- Toolbar
 
         btn_comp = QPushButton('Compute BRF')
@@ -208,13 +205,6 @@ class BRFManager(myqt.QFrameLayout):
         self.addWidget(QLabel('BRF End :'), row, 0)
         self.addWidget(self.date_end_edit, row, 1)
         row += 1
-        self.setRowMinimumHeight(row, 15)
-        row += 1
-        self.addWidget(self._detrend, row, 0, 1, 2)
-        row += 1
-        self.addWidget(self._correct, row, 0, 1, 2)
-        row += 1
-        self.setRowMinimumHeight(row, 5)
         self.setRowStretch(row, 100)
         row += 1
         self.addWidget(tbar, row, 0, 1, 3)
@@ -241,8 +231,8 @@ class BRFManager(myqt.QFrameLayout):
         return self.detrend_waterlevels_cbox.isChecked()
 
     @property
-    def correct_WL(self):
-        return 'No'
+    def correct_waterlevels(self):
+        return True
 
     def get_brfperiod(self):
         """

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -150,6 +150,7 @@ class BRFManager(myqt.QFrameLayout):
         self.detrend_waterlevels_cbox = QCheckBox('Detrend water levels')
         self.detrend_waterlevels_cbox.setChecked(True)
 
+        # ---- BRF date range
         self.date_start_edit = QDateTimeEdit()
         self.date_start_edit.setCalendarPopup(True)
         self.date_start_edit.setDisplayFormat('dd/MM/yyyy')
@@ -171,7 +172,6 @@ class BRFManager(myqt.QFrameLayout):
                                     "the mouse cursor on the graph.")
 
         # ---- Toolbar
-
         btn_comp = QPushButton('Compute BRF')
         btn_comp.clicked.connect(self.calc_brf)
         btn_comp.setFocusPolicy(Qt.NoFocus)
@@ -180,14 +180,12 @@ class BRFManager(myqt.QFrameLayout):
         btn_show.clicked.connect(self.viewer.show)
 
         # Layout
-
         tbar = myqt.QFrameLayout()
         tbar.addWidget(btn_comp, 0, 0)
         tbar.addWidget(btn_show, 0, 1)
         tbar.setColumnStretch(0, 100)
 
         # ---- Main Layout
-
         row = 0
         self.addWidget(self._bplag['label'], row, 0)
         self.addWidget(self._bplag['widget'], row, 1)
@@ -212,7 +210,6 @@ class BRFManager(myqt.QFrameLayout):
         self.setColumnStretch(self.columnCount(), 100)
 
         # ---- Install Panel
-
         if not KGSBRFInstaller().kgsbrf_is_installed():
             self.__install_kgs_brf_installer()
 

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -147,7 +147,8 @@ class BRFManager(myqt.QFrameLayout):
         self.correct_earthtides_cbox = QCheckBox('Correct for Earth tides')
         self.correct_earthtides_cbox.setChecked(True)
 
-        # ---- BRF Data Range ----
+        self.detrend_waterlevels_cbox = QCheckBox('Detrend water levels')
+        self.detrend_waterlevels_cbox.setChecked(True)
 
         self.date_start_edit = QDateTimeEdit()
         self.date_start_edit.setCalendarPopup(True)
@@ -168,11 +169,6 @@ class BRFManager(myqt.QFrameLayout):
         self.btn_seldata = OnOffToolButton('select_range', size='small')
         self.btn_seldata.setToolTip("Select a BRF calculation period with "
                                     "the mouse cursor on the graph.")
-
-        # ---- Detrend and Correct Options ----
-
-        self._detrend = QCheckBox('Detrend')
-        self._detrend.setCheckState(Qt.Checked)
 
         self._correct = QCheckBox('Correct WL')
         self._correct.setEnabled(False)
@@ -200,6 +196,8 @@ class BRFManager(myqt.QFrameLayout):
         self.addWidget(self._bplag['widget'], row, 1)
         row += 1
         self.addWidget(self.correct_earthtides_cbox, row, 0, 1, 2)
+        row += 1
+        self.addWidget(self.detrend_waterlevels_cbox, row, 0, 1, 2)
         row += 1
         self.setRowMinimumHeight(row, 15)
         row += 1
@@ -239,11 +237,8 @@ class BRFManager(myqt.QFrameLayout):
         return self.correct_earthtides_cbox.isChecked()
 
     @property
-    def detrend(self):
-        if self._detrend.checkState():
-            return 'Yes'
-        else:
-            return 'No'
+    def detrend_waterlevels(self):
+        return self.detrend_waterlevels_cbox.isChecked()
 
     @property
     def correct_WL(self):
@@ -329,7 +324,6 @@ class BRFManager(myqt.QFrameLayout):
         """Prepare the data, calcul the brf, and save and plot the results."""
 
         # Prepare the datasets.
-
         well = self.wldset['Well']
 
         brfperiod = self.get_brfperiod()
@@ -351,13 +345,7 @@ class BRFManager(myqt.QFrameLayout):
         if len(et) == 0:
             et = np.zeros(len(wl))
 
-        lagBP = self.lagBP
-        lagET = self.lagET
-        detrend = self.detrend
-        correct = self.correct_WL
-
         # Fill the gaps in the dataset.
-
         dt = np.min(np.diff(time))
         tc = np.arange(t1, t2+dt/2, dt)
         if len(tc) != len(time):

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -221,7 +221,7 @@ class BRFManager(myqt.QFrameLayout):
     # ---- Properties
 
     @property
-    def lagBP(self):
+    def nlag_baro(self):
         return self._bplag['widget'].value()
 
     @property

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -144,8 +144,10 @@ class BRFManager(myqt.QFrameLayout):
         self._bplag['widget'].setValue(300)
         self._bplag['widget'].setKeyboardTracking(True)
 
-        self.correct_earthtides_cbox = QCheckBox('Correct for Earth tides')
-        self.correct_earthtides_cbox.setChecked(True)
+        self.earthtides_spinbox = myqt.QDoubleSpinBox(100, 0)
+        self.earthtides_spinbox.setRange(-1, 9999)
+        self.earthtides_spinbox.setValue(300)
+        self.earthtides_spinbox.setKeyboardTracking(True)
 
         self.detrend_waterlevels_cbox = QCheckBox('Detrend water levels')
         self.detrend_waterlevels_cbox.setChecked(True)
@@ -190,6 +192,9 @@ class BRFManager(myqt.QFrameLayout):
         self.addWidget(self._bplag['label'], row, 0)
         self.addWidget(self._bplag['widget'], row, 1)
         row += 1
+        self.addWidget(QLabel('ET Lags Nbr:'), row, 0)
+        self.addWidget(self._bplag['widget'], row, 1)
+        
         self.addWidget(self.correct_earthtides_cbox, row, 0, 1, 2)
         row += 1
         self.addWidget(self.detrend_waterlevels_cbox, row, 0, 1, 2)
@@ -220,8 +225,8 @@ class BRFManager(myqt.QFrameLayout):
         return self._bplag['widget'].value()
 
     @property
-    def correct_earthtides(self):
-        return self.correct_earthtides_cbox.isChecked()
+    def nlag_earthtides(self):
+        return self.earthtides_spinbox.value()
 
     @property
     def detrend_waterlevels(self):
@@ -354,13 +359,13 @@ class BRFManager(myqt.QFrameLayout):
         bm.produce_BRFInputtxt(well, time, wl, bp, et)
         msg = 'Not enough data. Try enlarging the selected period'
         msg += ' or reduce the number of BP lags.'
-        if self.lagBP >= len(time):
+        if self.nlag_baro >= len(time) or self.nlag_earthtides >= len(time):
             QApplication.restoreOverrideCursor()
             QMessageBox.warning(self, 'Warning', msg, QMessageBox.Ok)
             return
 
         bm.produce_par_file(
-            self.lagBP, self.correct_earthtides, self.detrend_waterlevels,
+            self.nlag_baro, self.nlag_earthtides, self.detrend_waterlevels,
             self.correct_waterlevels)
         bm.run_kgsbrf()
 

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -358,7 +358,7 @@ class BRFManager(myqt.QFrameLayout):
             time = tc
 
         QApplication.setOverrideCursor(Qt.WaitCursor)
-        print('calculating BRF')
+        print('calculating the BRF')
 
         bm.produce_BRFInputtxt(well, time, wl, bp, et)
         msg = ("Not enough data. Try enlarging the selected period "
@@ -374,7 +374,7 @@ class BRFManager(myqt.QFrameLayout):
         bm.run_kgsbrf()
 
         try:
-            lag, A, err = bm.read_BRFOutput()
+            lag, A, err = bm.read_brf_output()
             date_start = self.date_start_edit.date().getDate()
             date_end = self.date_end_edit.date().getDate()
             self.wldset.save_brf(lag, A, err, date_start, date_end)

--- a/gwhat/brf_mod/tests/test_brf_mod.py
+++ b/gwhat/brf_mod/tests/test_brf_mod.py
@@ -87,10 +87,10 @@ def test_kgs_brf_defaults(brfmanager, wldataset, qtbot):
     brfmanager.set_wldset(wldataset)
     assert wldataset.get_brfperiod() == [41334.0, 41425.0]
 
-    assert brfmanager.lagBP == 300
-    assert brfmanager.lagET == 300
-    assert brfmanager.detrend == 'Yes'
-    assert brfmanager.correct_WL == 'No'
+    assert brfmanager.nlag_baro == 100
+    assert brfmanager.nlag_earthtides == 100
+    assert brfmanager.detrend_waterlevels is True
+    assert brfmanager.correct_waterlevels is True
     assert brfmanager.get_brfperiod() == [41334.0, 41425.0]
 
 

--- a/gwhat/common/widgets.py
+++ b/gwhat/common/widgets.py
@@ -58,7 +58,7 @@ class MyQComboBox(QComboBox):
 
 class QDoubleSpinBox(QDoubleSpinBox):
     def __init__(self, val, dec=0, step=None, units=None,
-                 parent=None, read_only=False):
+                 parent=None, read_only=False, show_buttons=False):
         super(QDoubleSpinBox, self).__init__(parent)
 
         self.__value = 0
@@ -80,7 +80,8 @@ class QDoubleSpinBox(QDoubleSpinBox):
         if units is not None:
             self.setSuffix(units)
 
-        self.setButtonSymbols(QAbstractSpinBox.NoButtons)
+        if show_buttons is False:
+            self.setButtonSymbols(QAbstractSpinBox.NoButtons)
         if read_only is True:
             self.setSpecialValueText('\u2014')
             self.setReadOnly(True)


### PR DESCRIPTION
Added a checkbox where it is possible to easily check or uncheck the option to compute the BRF by taking into accounts the Earth tides or not.

Also:
- Changed some variable names so that the code is easier to understand.
- Improve the code style.
- Made some improvement to the GUI.
- Removed the `correct WL` checkbox since it was useless and not connected to anything.
- Remove on valid values from the BRF results when the ET lag nbr > BP lag nbr.

![et_option](https://user-images.githubusercontent.com/10170372/52578037-65374500-2df1-11e9-8c56-782ed85a0876.gif)
