### PR TITLE
PR: Install req for packaging GWHAT in 'after_tests' step on AppVeyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ releases/gwhat_*
 run_cython.bat
 environment/
 
+build_ext.bat
 gwrecharge_calculs.c
 Colors.db
 kgs_brf.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,9 +35,6 @@ install:
   # Setup GWHAT dev requirements.
   - python -m pip install -r requirements-dev.txt
 
-  # Setup requirements for packaging GWHAT.
-  - python -m pip install pyinstaller pywin32 tornado
-
   # Build the extensions.
   - python setup.py build_ext --inplace
 
@@ -47,6 +44,10 @@ test_script:
   - python runtests.py
 
 after_test:
+  # Install requirements for packaging GWHAT.
+  - python -m pip install pyinstaller pywin32 tornado
+
+  # Package GWHAT with PyInstaller.
   - cmd: set PYTHONPATH=C:\projects\gwhat;%PYTHONPATH%
   - cd ./releases
   - pyinstaller.exe gwhat.spec


### PR DESCRIPTION
The idea of this PR is to install the requirements to package GWHAT after the tests have been run successfully.

This should make us save time when tests are failing.