### PR TITLE
PR: Fix compute BRF if nan are present in the water level dataset

### DIFF
--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -354,7 +354,7 @@ class BRFManager(myqt.QFrameLayout):
         # Fill the gaps in the waterlevel data.
         dt = np.min(np.diff(time))
         tc = np.arange(t1, t2+dt/2, dt)
-        if len(tc) != len(time):
+        if len(tc) != len(time) or np.any(np.isnan(wl)):
             print('Filling gaps in data with linear interpolation.')
             indx = np.where(~np.isnan(wl))[0]
             wl = np.interp(tc, time[indx], wl[indx])

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -351,7 +351,7 @@ class BRFManager(myqt.QFrameLayout):
         if len(et) == 0:
             et = np.zeros(len(wl))
 
-        # Fill the gaps in the dataset.
+        # Fill the gaps in the waterlevel data.
         dt = np.min(np.diff(time))
         tc = np.arange(t1, t2+dt/2, dt)
         if len(tc) != len(time):


### PR DESCRIPTION
The condition to determine whether missing data were present or not in the water level dataset was not robust enough. So this PR fixes this.