### PR TITLE
PR: Add an undo feature when making changes to the water level data

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -348,6 +348,13 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.btn_del_select = QToolButtonNormal('erase_data')
         self.btn_del_select.clicked.connect(self.delete_selected_wl)
 
+        self.btn_clear_changes = QToolButtonNormal('clear_changes')
+        self.btn_clear_changes.setToolTip(
+            "Clear all changes made to the water level data since the last "
+            "commit.")
+        self.btn_clear_changes.clicked.connect(self.clear_all_changes)
+        self.btn_clear_changes.setEnabled(False)
+
         self.btn_commit_changes = QToolButtonNormal('commit_changes')
         self.btn_commit_changes.clicked.connect(self.commit_wl_changes)
         self.btn_commit_changes.setEnabled(False)
@@ -360,7 +367,8 @@ class WLCalc(DialogWindow, SaveFileMixin):
                     self.btn_show_glue, self.btn_show_weather,
                     self.btn_show_mrc, self.btn_show_meas_wl, None,
                     self.btn_rect_select, self.btn_clear_select,
-                    self.btn_del_select, self.btn_commit_changes]:
+                    self.btn_del_select, self.btn_clear_changes,
+                    self.btn_commit_changes]:
             toolbar.addWidget(btn)
 
         return toolbar

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -813,6 +813,17 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
     # ---- Drawing methods
 
+    def _add_to_undo_stack(self, indexes):
+        """
+        Store the old water level values at the specified indexes in a stack
+        before changing or deleting them. This allow to undo or cancel any
+        changes made to the water level data before commiting them.
+        """
+        if len(indexes):
+            self._wldset_undo_stack.append((indexes, self.water_lvl[indexes]))
+        self.btn_commit_changes.setEnabled(len(self._wldset_undo_stack))
+        self.btn_clear_changes.setEnabled(len(self._wldset_undo_stack))
+
     def setup_hydrograph(self):
         """Setup the hydrograph after a new wldset has been set."""
         self.peak_indx = np.array([]).astype(int)

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -812,6 +812,16 @@ class WLCalc(DialogWindow, SaveFileMixin):
             self.draw_mrc()
 
     # ---- Drawing methods
+    def clear_all_changes(self):
+        """Clear all changes that were made to the wldset."""
+        for change in self._wldset_undo_stack:
+            self.water_lvl[change[0]] = change[1]
+        self._wldset_undo_stack = []
+        self._obs_wl_plt.set_ydata(self.water_lvl)
+        self.clear_selected_wl()
+        self.btn_commit_changes.setEnabled(False)
+        self.btn_clear_changes.setEnabled(False)
+
 
     def _add_to_undo_stack(self, indexes):
         """

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -349,6 +349,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.btn_undo_changes.setToolTip(
             "Undo the last changes made to the water level data.")
         self.btn_undo_changes.setEnabled(False)
+        self.btn_undo_changes.clicked.connect(self.undo_wl_changes)
 
         self.btn_clear_changes = QToolButtonNormal('clear_changes')
         self.btn_clear_changes.setToolTip(

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -87,6 +87,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
         self.time = []
         self.water_lvl = []
+        self._wldset_undo_stack = []
 
         # Calcul the delta between the datum of Excel and Maplotlib numeric
         # date system.

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -349,6 +349,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
         self.btn_commit_changes = QToolButtonNormal('commit_changes')
         self.btn_commit_changes.clicked.connect(self.commit_wl_changes)
+        self.btn_commit_changes.setEnabled(False)
 
         # Setup the layout.
         toolbar = ToolBarWidget()

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -502,6 +502,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
     @property
     def wldset(self):
+        """Return the water level dataset."""
         return self.dmngr.get_current_wldset()
 
     @property

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -830,6 +830,8 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.peak_memory = [np.array([]).astype(int)]
         self.btn_undo.setEnabled(False)
         self.clear_selected_wl()
+        self.btn_commit_changes.setEnabled(False)
+        self.btn_clear_changes.setEnabled(False)
 
         # Plot observed and predicted water levels
         self._obs_wl_plt.set_data(

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -817,6 +817,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
         if len(self.wl_selected_i) and self.wldset is not None:
             self.wldset.delete_waterlevels_at(self.wl_selected_i)
             self._draw_obs_wl()
+            self._update_edit_toolbar_state()
 
     def undo_wl_changes(self):
         """Undo the last changes made to the water level data."""
@@ -828,7 +829,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
     def clear_all_changes(self):
         """Clear all changes that were made to the wldset."""
         if self.wldset is not None:
-            self.clear_all_changes.clear_all_changes()
+            self.wldset.clear_all_changes()
             self._draw_obs_wl()
             self._update_edit_toolbar_state()
 

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -779,12 +779,6 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.wl_selected_i = []
         self.draw_select_wl()
 
-    def delete_selected_wl(self):
-        """Delete the selecte water level data."""
-        self.water_lvl[self.wl_selected_i] = np.nan
-        self._obs_wl_plt.set_ydata(self.water_lvl)
-        self.clear_selected_wl()
-
     def commit_wl_changes(self):
         """Commit the changes made to the water level data to the project."""
         if self.wldset is not None:
@@ -811,7 +805,15 @@ class WLCalc(DialogWindow, SaveFileMixin):
             del self.peak_memory[-1]
             self.draw_mrc()
 
-    # ---- Drawing methods
+    # ---- Water level edit tools
+    def delete_selected_wl(self):
+        """Delete the selecte water level data."""
+        if len(self.wl_selected_i):
+            self._add_to_undo_stack(self.wl_selected_i)
+            self.water_lvl[self.wl_selected_i] = np.nan
+            self._obs_wl_plt.set_ydata(self.water_lvl)
+        self.clear_selected_wl()
+
     def clear_all_changes(self):
         """Clear all changes that were made to the wldset."""
         for change in self._wldset_undo_stack:
@@ -834,6 +836,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.btn_commit_changes.setEnabled(len(self._wldset_undo_stack))
         self.btn_clear_changes.setEnabled(len(self._wldset_undo_stack))
 
+    # ---- Drawing methods
     def setup_hydrograph(self):
         """Setup the hydrograph after a new wldset has been set."""
         self.peak_indx = np.array([]).astype(int)

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -779,13 +779,6 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.wl_selected_i = []
         self.draw_select_wl()
 
-    def commit_wl_changes(self):
-        """Commit the changes made to the water level data to the project."""
-        if self.wldset is not None:
-            self.wldset.dset['WL'][:] = self.water_lvl
-            self.wldset.dset.file.flush()
-            print('commit_wl_changes')
-
     def home(self):
         """Reset the orgininal view of the figure."""
         self.toolbar.home()
@@ -824,6 +817,14 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.btn_commit_changes.setEnabled(False)
         self.btn_clear_changes.setEnabled(False)
 
+    def commit_wl_changes(self):
+        """Commit the changes made to the water level data to the project."""
+        if self.wldset is not None:
+            self.wldset.dset['WL'][:] = self.water_lvl
+            self.wldset.dset.file.flush()
+            self.btn_commit_changes.setEnabled(False)
+            self.btn_clear_changes.setEnabled(False)
+            print('Changes commited successfully.')
 
     def _add_to_undo_stack(self, indexes):
         """

--- a/gwhat/brf_mod/tests/test_brf_mod.py
+++ b/gwhat/brf_mod/tests/test_brf_mod.py
@@ -18,7 +18,7 @@ from PyQt5.QtCore import Qt
 from gwhat.brf_mod.kgs_gui import (BRFManager, KGSBRFInstaller, QMessageBox,
                                    QFileDialog)
 from gwhat.projet.reader_projet import ProjetReader
-from gwhat.projet.reader_waterlvl import read_water_level_datafile
+from gwhat.projet.reader_waterlvl import WLDataFrame
 
 
 # ---- Pytest Fixtures
@@ -36,7 +36,7 @@ def wldataset(project):
     # Create a wldset object from a file.
     rootpath = osp.dirname(osp.realpath(__file__))
     filepath = osp.join(rootpath, 'data', 'sample_water_level_datafile.csv')
-    wldset = read_water_level_datafile(filepath)
+    wldset = WLDataFrame(filepath)
 
     # Add the wldset to the project.
     project.add_wldset('test_brf_wldset', wldset)

--- a/gwhat/meteo/weather_reader.py
+++ b/gwhat/meteo/weather_reader.py
@@ -7,7 +7,7 @@
 # Licensed under the terms of the GNU General Public License.
 
 
-# ---- Standard Library imports
+# ---- Standard library imports
 
 import os
 import os.path as osp
@@ -17,14 +17,14 @@ from time import strftime
 from collections.abc import Mapping
 from abc import abstractmethod
 
-# ---- Third Party imports
+# ---- Third party imports
 
 import numpy as np
 from xlrd.xldate import xldate_from_datetime_tuple, xldate_from_date_tuple
 from xlrd import xldate_as_tuple
 
 
-# ---- Local Library imports
+# ---- Local library imports
 
 from gwhat.meteo.evapotranspiration import calcul_Thornthwaite
 from gwhat.common.utils import save_content_to_csv, save_content_to_file

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -182,7 +182,7 @@ class DataManager(QWidget):
     def set_projet(self, projet):
         """Set the namespace for the projet hdf5 file."""
         self._projet = projet
-        if isinstance(projet, ProjetReader):
+        if projet is not None:
             self.update_wldsets(projet.get_last_opened_wldset())
             self.update_wxdsets(projet.get_last_opened_wxdset())
 

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -26,7 +26,7 @@ import gwhat.common.widgets as myqt
 from gwhat.hydrograph4 import LatLong2Dist
 import gwhat.projet.reader_waterlvl as wlrd
 from gwhat.projet.reader_projet import (INVALID_CHARS, is_dsetname_valid,
-                                        make_dsetname_valid, ProjetReader)
+                                        make_dsetname_valid)
 import gwhat.meteo.weather_reader as wxrd
 from gwhat.widgets.buttons import ToolBarWidget
 from gwhat.widgets.spinboxes import StrSpinBox
@@ -809,12 +809,11 @@ class NewDatasetDialog(QDialog):
         self.update_gui()
 
 
-# %% if __name__ == '__main__'
-
 if __name__ == '__main__':
-    from reader_projet import ProjetReader
     import sys
-    projet = ProjetReader("C:/Users/jsgosselin/gwhat/Projects/Example/Example.gwt")
+    from gwhat.projet.reader_projet import ProjetReader
+    projet = ProjetReader(
+        "C:/Users/jsgosselin/gwhat/Projects/Example/Example.gwt")
 
     app = QApplication(sys.argv)
 

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -408,8 +408,16 @@ class WLDataFrameHDF5(WLDataFrameBase):
     def name(self):
         return osp.basename(self.dset.name)
 
-    # ---- Manual measurents
+    # ---- Water levels
+    def commit(self):
+        """Commit the changes made to the water level data to the project."""
+        if self.has_uncommited_changes:
+            self.dset['WL'][:] = self.__waterlevels
+            self.dset.file.flush()
+            self._undo_stack = []
+            print('Changes commited successfully.')
 
+    # ---- Manual measurements
     def set_wlmeas(self, time, wl):
         """Overwrite the water level measurements for this dataset."""
         try:

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -381,8 +381,8 @@ class WLDataFrameHDF5(WLDataFrameBase):
     def __load_dataset__(self, hdf5group):
         self.dset = hdf5group
         self._undo_stack = []
-        self._waterlevels = self.dset['WL']
-        self._datetimes = self.dset['Time']
+        self._waterlevels = self.dset['WL'][...]
+        self._datetimes = self.dset['Time'][...]
 
         # Make older datasets compatible with newer format.
         if 'Well ID' not in list(self.dset.attrs.keys()):

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -412,7 +412,7 @@ class WLDataFrameHDF5(WLDataFrameBase):
     def commit(self):
         """Commit the changes made to the water level data to the project."""
         if self.has_uncommited_changes:
-            self.dset['WL'][:] = self.__waterlevels
+            self.dset['WL'][:] = np.copy(self.waterlevels)
             self.dset.file.flush()
             self._undo_stack = []
             print('Changes commited successfully.')

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -20,6 +20,7 @@ import numpy as np
 
 # ---- Local library imports
 from gwhat.meteo.weather_reader import WXDataFrameBase
+from gwhat.projet.reader_waterlvl import WLDataFrameBase
 from gwhat.gwrecharge.glue import GLUEDataFrameBase
 from gwhat.common.utils import save_content_to_file
 from gwhat.utils.math import nan_as_text_tolist, calcul_rmse
@@ -365,7 +366,7 @@ class ProjetReader(object):
         self.db.flush()
 
 
-class WLDataFrameHDF5(dict):
+class WLDataFrameHDF5(WLDataFrameBase):
     """
     This is a wrapper around the h5py group that is used to store
     water level datasets. It mimick the structure of the DataFrame that
@@ -373,19 +374,24 @@ class WLDataFrameHDF5(dict):
     reader_waterlvl module.
     """
 
-    def __init__(self, dset, *args, **kwargs):
+    def __init__(self, hdf5group, *args, **kwargs):
         super(WLDataFrameHDF5, self).__init__(*args, **kwargs)
-        self.dset = dset
+        self.__load_dataset__(hdf5group)
 
-        # Make older datasets compatible with newer format :
+    def __load_dataset__(self, hdf5group):
+        self.dset = hdf5group
+        self._undo_stack = []
+        self._waterlevels = self.dset['WL']
+        self._datetimes = self.dset['Time']
 
+        # Make older datasets compatible with newer format.
         if 'Well ID' not in list(self.dset.attrs.keys()):
             # Added in version 0.2.1 (see PR #124).
-            dset.attrs['Well ID'] = ""
+            self.dset.attrs['Well ID'] = ""
             self.dset.file.flush()
         if 'Province' not in list(self.dset.attrs.keys()):
             # Added in version 0.2.1 (see PR #124).
-            dset.attrs['Province'] = ""
+            self.dset.attrs['Province'] = ""
             self.dset.file.flush()
         if 'glue' not in list(self.dset.keys()):
             # Added in version 0.3.1 (see PR #184)

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -291,6 +291,24 @@ class WLDataFrameBase(Mapping):
         return NotImplementedError
 
 
+class WLDataFrame(WLDataFrameBase):
+    """A water level dataset container that loads its data from a file."""
+
+    def __init__(self, filename, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__load_dataset__(filename)
+
+    def __getitem__(self, key):
+        """Returns the value saved in the store at key."""
+        return self.dset.__getitem__(key)
+
+    def __load_dataset__(self, filename):
+        """Loads the dataset from a file and saves it in the store."""
+        self.dset = read_water_level_datafile(filename)
+        self._waterlevels = self.dset['WL']
+        self._datetimes = self.dset['Time']
+
+
 if __name__ == "__main__":
     df = read_water_level_datafile("PO01_15min.xlsx")
     df2 = read_water_level_datafile("PO01_15min.xls")

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -13,6 +13,7 @@ import os.path as osp
 import numpy as np
 import xlrd
 import csv
+from collections.abc import Mapping
 
 
 # ---- Local library imports

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -293,11 +293,11 @@ class WLDataFrameBase(Mapping):
     # ---- Water levels
     @property
     def datetimes(self):
-        return np.copy(self._datetimes)
+        return self._datetimes
 
     @property
     def waterlevels(self):
-        return np.copy(self._waterlevels)
+        return self._waterlevels
 
     @property
     def has_uncommited_changes(self):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -264,6 +264,31 @@ def generate_HTML_table(name, lat, lon, alt, mun):
     return table
 
 
+class WLDataFrameBase(Mapping):
+    """
+    A water level data frame base class.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dset = None
+        self._undo_stack = []
+        self._waterlevels = np.array([])
+        self._datetimes = np.array([])
+
+    def __load_dataset__(self):
+        """Loads the dataset and save it in a store."""
+        raise NotImplementedError
+
+    def __len__(self, key):
+        return len(self._datetimes)
+
+    def __setitem__(self, key, value):
+        return NotImplementedError
+
+    def __iter__(self):
+        return NotImplementedError
+
 
 if __name__ == "__main__":
     df = read_water_level_datafile("PO01_15min.xlsx")

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -310,6 +310,10 @@ class WLDataFrame(WLDataFrameBase):
 
 
 if __name__ == "__main__":
-    df = read_water_level_datafile("PO01_15min.xlsx")
-    df2 = read_water_level_datafile("PO01_15min.xls")
-    df3 = read_water_level_datafile("PO01_15min.csv")
+    from gwhat import __rootdir__
+    df = WLDataFrame(
+        osp.join(__rootdir__, 'tests', "water_level_datafile.csv"))
+    df2 = WLDataFrame(
+        osp.join(__rootdir__, 'tests', "water_level_datafile.xls"))
+    df3 = WLDataFrame(
+        osp.join(__rootdir__, 'tests', "water_level_datafile.xlsx"))

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -6,21 +6,22 @@
 # This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
 # Licensed under the terms of the GNU General Public License.
 
+
+# ---- Standard library imports
 import os
+import os.path as osp
 import numpy as np
 import xlrd
 import csv
 
 
-# ---- Imports: local
-
+# ---- Local library imports
 from gwhat.common.utils import save_content_to_csv
 
 FILE_EXTS = ['.csv', '.xls', '.xlsx']
 
 
 # ---- Read and Load Water Level Datafiles
-
 def open_water_level_datafile(filename):
     """Open a water level data file and return the data."""
     root, ext = os.path.splitext(filename)
@@ -61,9 +62,8 @@ def read_water_level_datafile(filename):
           'ET': np.array([])}
 
     # ---- Read the Header
-
     for row, line in enumerate(data):
-        if len(line) == 0:
+        if not len(line):
             continue
 
         try:
@@ -106,7 +106,6 @@ def read_water_level_datafile(filename):
         return None
 
     # ---- Read the Data
-
     try:
         data = np.array(data[row+1:])
     except IndexError:
@@ -114,7 +113,6 @@ def read_water_level_datafile(filename):
         return df
 
     # Read the water level data :
-
     try:
         df['Time'] = data[:, 0].astype(float)
         df['WL'] = data[:, 1].astype(float)
@@ -130,49 +128,45 @@ def read_water_level_datafile(filename):
         print("The data are not monotically increasing in time.")
         return None
 
-    # Read the barometric data
-
+    # Read the barometric data.
     try:
         if column_labels[2] == 'BP(m)':
             df['BP'] = data[:, 2].astype(float)
         else:
             print('No barometric data.')
-    except:
+    except IndexError:
         print('No barometric data.')
 
-    # Read the earth tide data :
-
+    # Read the Earth tides data.
     try:
         if column_labels[3] == 'ET':
             df['ET'] = data[:, 3].astype(float)
         else:
             print('No Earth tide data.')
-    except:
+    except IndexError:
         print('No Earth tide data.')
 
     return df
 
 
 def make_waterlvl_continuous(t, wl):
-    # This method produce a continuous daily water level time series.
-    # Missing data are filled with nan values.
-
+    """
+    This method produce a continuous daily water level time series.
+    Missing data are filled with nan values.
+    """
     print('Making water level continuous...')
-
     i = 1
     while i < len(t)-1:
         if t[i+1]-t[i] > 1:
             wl = np.insert(wl, i+1, np.nan, 0)
             t = np.insert(t, i+1, t[i]+1, 0)
         i += 1
-
     print('Making water level continuous done.')
 
     return t, wl
 
 
 # ---- Water Level Manual Measurements
-
 def init_waterlvl_measures(dirname):
     """
     Create an empty waterlvl_manual_measurements.csv file with headers
@@ -270,7 +264,6 @@ def generate_HTML_table(name, lat, lon, alt, mun):
     return table
 
 
-# ---- if __name__ == "__main__"
 
 if __name__ == "__main__":
     df = read_water_level_datafile("PO01_15min.xlsx")

--- a/gwhat/projet/tests/test_manager_data.py
+++ b/gwhat/projet/tests/test_manager_data.py
@@ -18,7 +18,7 @@ from PyQt5.QtCore import Qt
 
 # ---- Local Libraries Imports
 from gwhat.meteo.weather_reader import WXDataFrame
-from gwhat.projet.reader_waterlvl import read_water_level_datafile
+from gwhat.projet.reader_waterlvl import WLDataFrame
 from gwhat.projet.reader_projet import ProjetReader
 from gwhat.projet.manager_data import (DataManager, QFileDialog, QMessageBox,
                                        QCheckBox)
@@ -145,10 +145,8 @@ def test_delete_waterlevel_data(datamanager, mocker, qtbot):
     """
     Test deleting water level datasets from the project.
     """
-    datamanager.new_wldset_imported(
-        'wldset1', read_water_level_datafile(WLFILENAME))
-    datamanager.new_wldset_imported(
-        'wldset2', read_water_level_datafile(WLFILENAME))
+    datamanager.new_wldset_imported('wldset1', WLDataFrame(WLFILENAME))
+    datamanager.new_wldset_imported('wldset2', WLDataFrame(WLFILENAME))
     assert datamanager.wldataset_count() == 2
 
     # Click to delete the current water level dataset, but cancel.
@@ -190,8 +188,7 @@ def test_last_opened_datasets(qtbot, projectpath):
 
     # Add some water level dataset.
     for name in ['wldset1', 'wldset2', 'wldset3']:
-        datamanager.new_wldset_imported(
-            name, read_water_level_datafile(WLFILENAME))
+        datamanager.new_wldset_imported(name, WLDataFrame(WLFILENAME))
     assert datamanager.get_current_wldset().name == 'wldset3'
 
     # Add some weather dataset.

--- a/gwhat/tests/test_hydrocalc.py
+++ b/gwhat/tests/test_hydrocalc.py
@@ -16,7 +16,7 @@ from PyQt5.QtCore import Qt
 
 # ---- Local Libraries Imports
 from gwhat.meteo.weather_reader import WXDataFrame
-from gwhat.projet.reader_waterlvl import read_water_level_datafile
+from gwhat.projet.reader_waterlvl import WLDataFrame
 from gwhat.HydroCalc2 import WLCalc
 from gwhat.projet.manager_data import DataManager
 from gwhat.projet.reader_projet import ProjetReader
@@ -44,7 +44,7 @@ def project(projectpath):
     project.add_wxdset(wxdset['Station Name'], wxdset)
 
     # Add the water level dataset to the project.
-    wldset = read_water_level_datafile(WLFILENAME)
+    wldset = WLDataFrame(WLFILENAME)
     project.add_wldset(wldset['Well'], wldset)
     return project
 

--- a/gwhat/tests/test_hydroprint.py
+++ b/gwhat/tests/test_hydroprint.py
@@ -16,7 +16,7 @@ from PyQt5.QtCore import Qt
 
 # ---- Local Libraries Imports
 from gwhat.meteo.weather_reader import WXDataFrame
-from gwhat.projet.reader_waterlvl import read_water_level_datafile
+from gwhat.projet.reader_waterlvl import WLDataFrame
 from gwhat.HydroPrint2 import (HydroprintGUI, PageSetupWin, QFileDialog,
                                QMessageBox)
 from gwhat.projet.manager_data import DataManager
@@ -49,7 +49,7 @@ def project(projectpath):
         project.add_wxdset(wxdset['Station Name'], wxdset)
 
     # Add the water level dataset to the project.
-    wldset = read_water_level_datafile(WLFILENAME)
+    wldset = WLDataFrame(WLFILENAME)
     project.add_wldset(wldset['Well'], wldset)
     return project
 

--- a/gwhat/utils/icons.py
+++ b/gwhat/utils/icons.py
@@ -97,7 +97,12 @@ GWHAT_ICONS = {
 
 COLOR = '#4d4d4d'
 GREEN = '#00aa00'
+RED = '#aa0000'
+
 FA_ICONS = {
+    'clear_changes': [
+        ('mdi.close-circle-outline',),
+        {'color': RED, 'scale_factor': 1.3}],
     'close_all': [
         ('fa.close', 'fa.close', 'fa.close'),
         {'options': [{'scale_factor': 0.6,

--- a/gwhat/utils/icons.py
+++ b/gwhat/utils/icons.py
@@ -129,6 +129,9 @@ FA_ICONS = {
     'pan': [
         ('mdi.pan',),
         {'color': COLOR, 'scale_factor': 1.3}],
+    'undo_changes': [
+        ('mdi.undo-variant',),
+        {'color': COLOR, 'scale_factor': 1.3}],
     }
 
 ICON_SIZES = {'large': (32, 32),


### PR DESCRIPTION
- Added an `undo` feature that allows to undo the last changes made to the water level data
- Added an `clear` feature that allows to undo all changes made to the water level data since the last commit.
- Created a `WLDataFrameBase` and `WLDataFrame` classes that holds all the code for the undo feature.

![undo_cancel_changes](https://user-images.githubusercontent.com/10170372/52725377-18817480-2f7f-11e9-9e48-c543f84da143.gif)