### PR TITLE
PR: Improve toolbutton tooltips

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -304,7 +304,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
         # ---- Show/Hide section
         self.btn_show_glue = OnOffToolButton('show_glue_wl', size='normal')
         self.btn_show_glue.setToolTip(
-            """Show or hide GLUE water level 05/95 envelope.""")
+            "Show or hide GLUE water level 05/95 envelope.")
         self.btn_show_glue.sig_value_changed.connect(self.draw_glue_wl)
         self.btn_show_glue.setValue(True, silent=True)
 
@@ -315,7 +315,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
         self.btn_show_mrc = OnOffToolButton('mrc_calc', size='normal')
         self.btn_show_mrc.setToolTip(
-            """Show or hide water levels predicted with the MRC.""")
+            "Show or hide water levels predicted with the MRC.")
         self.btn_show_mrc.sig_value_changed.connect(
             self.btn_show_mrc_isclicked)
         self.btn_show_mrc.setValue(True, silent=True)
@@ -323,15 +323,15 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.btn_show_meas_wl = OnOffToolButton(
             'manual_measures', size='normal')
         self.btn_show_meas_wl.setToolTip(
-            """Show or hide water levels measured manually in the well.""")
+            "Show or hide water levels measured manually in the well.")
         self.btn_show_meas_wl.setValue(True, silent=True)
         self.btn_show_meas_wl.sig_value_changed.connect(self.draw_meas_wl)
 
         # ---- Select and transform data.
         self.btn_rect_select = OnOffToolButton('rect_select', size='normal')
         self.btn_rect_select.setToolTip(
-            "<p>Select water level data by clicking with the mouse and "
-            "dragging the cursor over a rectangular region of the graph.</p>")
+            "Select water level data by clicking with the mouse and "
+            "dragging the cursor over a rectangular region of the graph.")
         self.btn_rect_select.sig_value_changed.connect(
             self.rect_select_is_active_changed)
         self.register_navig_and_select_tool(self.btn_rect_select)

--- a/gwhat/utils/icons.py
+++ b/gwhat/utils/icons.py
@@ -155,12 +155,23 @@ def get_iconsize(size):
 
 
 class QToolButtonBase(QToolButton):
+    """A basic tool button."""
+
     def __init__(self, icon, *args, **kargs):
         super(QToolButtonBase, self).__init__(*args, **kargs)
         icon = get_icon(icon) if isinstance(icon, str) else icon
         self.setIcon(icon)
         self.setAutoRaise(True)
         self.setFocusPolicy(Qt.NoFocus)
+
+    def setToolTip(self, ttip):
+        """
+        Qt method override to ensure tooltips are enclosed in <p></p> so
+        that they wraps correctly.
+        """
+        ttip = ttip if ttip.startswith('<p>') else '<p>' + ttip
+        ttip = ttip if ttip.endswith('</p>') else ttip + '</p>'
+        super().setToolTip(ttip)
 
 
 class QToolButtonNormal(QToolButtonBase):


### PR DESCRIPTION
The idea is to prevent tool-tips from showing on a single very long line by enclosing the tool-tip text in html `<p></p>`

For example, here it how it looks with the changes proposed in this PR:

![image](https://user-images.githubusercontent.com/10170372/52737084-791dab00-2f99-11e9-8bf7-d68dd9775a22.png)
