### PR TITLE
PR: Rename "close_projet" methot of the "ProjetReader" class to "close"

### DIFF
--- a/gwhat/projet/manager_projet.py
+++ b/gwhat/projet/manager_projet.py
@@ -206,7 +206,7 @@ class ProjetManager(QWidget):
         try:
             backup = ProjetReader(filename + '.bak')
             assert backup.check_project_file() is True
-            backup.close_projet()
+            backup.close()
         except Exception:
             msg_box.exec_()
             return False
@@ -227,7 +227,7 @@ class ProjetManager(QWidget):
     def close_projet(self):
         """Close the currently opened hdf5 project file."""
         if self.projet is not None:
-            self.projet.close_projet()
+            self.projet.close()
             self.projet = None
 
     def show_newproject_dialog(self):

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -34,7 +34,7 @@ class ProjetReader(object):
         self.load_projet(filename)
 
     def __del__(self):
-        self.close_projet()
+        self.close()
 
     @property
     def db(self):  # project data base
@@ -50,7 +50,7 @@ class ProjetReader(object):
 
     def load_projet(self, filename):
         """Open the hdf5 project file."""
-        self.close_projet()
+        self.close()
         print("Loading project from '{}'... ".format(osp.basename(filename)),
               end='')
         try:
@@ -79,7 +79,7 @@ class ProjetReader(object):
                 # Added in version 0.4.0 (see PR #267)
                 self.db[key].attrs['last_opened'] = 'None'
 
-    def close_projet(self):
+    def close(self):
         """Close the project hdf5 file."""
         try:
             self.db.close()

--- a/gwhat/projet/tests/test_manager_data.py
+++ b/gwhat/projet/tests/test_manager_data.py
@@ -203,7 +203,7 @@ def test_last_opened_datasets(qtbot, projectpath):
     assert datamanager.get_current_wxdset().name == 'wxdset2'
 
     # Close the datamanager and its project.
-    datamanager.projet.close_projet()
+    datamanager.projet.close()
     datamanager.close()
 
     # Create a new datamanager and assert that the last opened water level

--- a/gwhat/projet/tests/test_project.py
+++ b/gwhat/projet/tests/test_project.py
@@ -41,7 +41,7 @@ def projectfile(projectpath):
     project.lat = LAT
     project.lon = LON
 
-    project.close_projet()
+    project.close()
 
     return projectpath
 
@@ -51,7 +51,7 @@ def bakfile(projectfile):
     """A path to a valid project backup file."""
     project = ProjetReader(projectfile)
     project.backup_project_file()
-    project.close_projet()
+    project.close()
     assert osp.exists(projectfile + '.bak')
     return projectfile + '.bak'
 


### PR DESCRIPTION
I think this makes the code clearer and easier to understand.

Moreover, this also correct a typo that was present in `close_projet`...