### PR TITLE
PR: Make the button to delete peaks in the MRC tool working again

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -703,7 +703,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
     def btn_delpeak_isclicked(self):
         """Handle when the button btn_delpeak is clicked."""
         if self.btn_delpeak.value():
-            self.toggle_navig_and_select_tools(self.btn_addpeak)
+            self.toggle_navig_and_select_tools(self.btn_delpeak)
             self.btn_show_mrc.setValue(True)
         self.draw()
 


### PR DESCRIPTION
The button to remove peak on the hydrograph to compute the MRC was not working due to a typo in the code.

![image](https://user-images.githubusercontent.com/10170372/55018967-5637db00-4fca-11e9-9b29-bebb7bffa4f2.png)
