### PR TITLE
PR: Store water levels in a Pandas DataFrame and index time with datetime instead of Excel numerical date

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -519,7 +519,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
     @property
     def time(self):
-        return np.array([]) if self.wldset is None else self.wldset.datetimes
+        return np.array([]) if self.wldset is None else self.wldset.xldates
 
     @property
     def wldset(self):
@@ -1228,8 +1228,8 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.clear_selected_wl(draw=False)
         if self.wldset is not None:
             self._obs_wl_plt.set_data(
-                self.wldset.datetimes + (self.dt4xls2mpl * self.dformat),
-                self.wldset.waterlevels)
+                self.time + (self.dt4xls2mpl * self.dformat),
+                self.water_lvl)
         self._obs_wl_plt.set_visible(self.wldset is not None)
         if draw:
             self.draw()

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -480,7 +480,7 @@ class HydroprintGUI(myqt.DialogWindow):
     def best_fit_time(self):
         wldset = self.dmngr.get_current_wldset()
         if wldset is not None:
-            date0, date1 = self.hydrograph.best_fit_time(wldset['Time'])
+            date0, date1 = self.hydrograph.best_fit_time(wldset.xldates)
             self.date_start_widget.setDate(QDate(date0[0], date0[1], date0[2]))
             self.date_end_widget.setDate(QDate(date1[0], date1[1], date1[2]))
 

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -306,15 +306,13 @@ class BRFManager(myqt.QFrameLayout):
         self.btn_seldata.setAutoRaise(True)
         self.setEnabled(wldset is not None)
         if wldset is not None:
-            self.set_daterange((self.wldset['Time'][0],
-                                self.wldset['Time'][-1]))
+            xldates = self.wldset.xldates
+            self.set_daterange((xldates[0], xldates[-1]))
 
             # Set the period over which the BRF would be evaluated.
             saved_brfperiod = wldset.get_brfperiod()
-            self.set_brfperiod(
-                (saved_brfperiod[0] or np.floor(self.wldset['Time'][0]),
-                 saved_brfperiod[1] or np.floor(self.wldset['Time'][-1])
-                 ))
+            self.set_brfperiod((saved_brfperiod[0] or np.floor(xldates[0]),
+                                saved_brfperiod[1] or np.floor(xldates[-1])))
 
     def set_daterange(self, daterange):
         """
@@ -335,11 +333,11 @@ class BRFManager(myqt.QFrameLayout):
 
         brfperiod = self.get_brfperiod()
         t1 = min(brfperiod)
-        i1 = np.where(self.wldset['Time'] >= t1)[0][0]
+        i1 = np.where(self.wldset.xldates >= t1)[0][0]
         t2 = max(brfperiod)
-        i2 = np.where(self.wldset['Time'] <= t2)[0][-1]
+        i2 = np.where(self.wldset.xldates <= t2)[0][-1]
 
-        time = np.copy(self.wldset['Time'][i1:i2+1])
+        time = np.copy(self.wldset.xldates[i1:i2+1])
         wl = np.copy(self.wldset['WL'][i1:i2+1])
         bp = np.copy(self.wldset['BP'][i1:i2+1])
         if len(bp) == 0:

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -98,8 +98,8 @@ class RechgEvalWorker(QObject):
 
         self.wldset = wldset
         self.A, self.B = wldset['mrc/params']
-        self.twlvl, self.wlobs = self.make_data_daily(wldset['Time'],
-                                                      wldset['WL'])
+        self.twlvl, self.wlobs = self.make_data_daily(
+            wldset.xldate, wldset['WL'])
 
         if not self.A and not self.B:
             error = ("Groundwater recharge cannot be computed because a"

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -1333,7 +1333,7 @@ if __name__ == '__main__':
         # 0: daily | 1: weekly | 2: monthly | 3: yearly
         hydrograph.RAINscale = 100
 
-        hydrograph.best_fit_time(wldset['Time'])
+        hydrograph.best_fit_time(wldset.xldate)
         hydrograph.best_fit_waterlvl()
         hydrograph.generate_hydrograph()
 #

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -855,7 +855,7 @@ class Hydrograph(Figure):
 
         # ---- Logger Measures
 
-        time = self.wldset['Time']
+        time = self.wldset.xldates
         if self.WLdatum == 1:  # masl
             water_lvl = self.wldset['Elevation']-self.wldset['WL']
         else:  # mbgs -> yaxis is inverted

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -24,10 +24,10 @@ from gwhat.utils.icons import QToolButtonSmall
 from gwhat.utils import icons
 import gwhat.common.widgets as myqt
 from gwhat.hydrograph4 import LatLong2Dist
-import gwhat.projet.reader_waterlvl as wlrd
+from gwhat.projet.reader_waterlvl import WLDataFrame
 from gwhat.projet.reader_projet import (INVALID_CHARS, is_dsetname_valid,
                                         make_dsetname_valid)
-import gwhat.meteo.weather_reader as wxrd
+from gwhat.meteo.weather_reader import WXDataFrame
 from gwhat.widgets.buttons import ToolBarWidget
 from gwhat.widgets.spinboxes import StrSpinBox
 
@@ -698,9 +698,9 @@ class NewDatasetDialog(QDialog):
 
         try:
             if self._datatype == 'water level':
-                self._dataset = wlrd.read_water_level_datafile(filename)
+                self._dataset = WLDataFrame(filename)
             elif self._datatype == 'daily weather':
-                self._dataset = wxrd.WXDataFrame(filename)
+                self._dataset = WXDataFrame(filename)
         except Exception:
             self._dataset = None
 

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -124,7 +124,6 @@ class ProjetReader(object):
             print('done')
             return True
 
-
     # ---- Project Properties
     @property
     def name(self):
@@ -183,7 +182,6 @@ class ProjetReader(object):
         self.db.attrs['longitude'] = x
 
     # ---- Water Levels Dataset Handlers
-
     @property
     def wldsets(self):
         """
@@ -280,7 +278,6 @@ class ProjetReader(object):
         self.db.flush()
 
     # ---- Weather Dataset Handlers
-
     @property
     def wxdsets(self):
         """

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -10,7 +10,6 @@ from __future__ import division, unicode_literals
 
 # ---- Standard library imports
 import os
-import csv
 import os.path as osp
 from shutil import copyfile
 
@@ -20,7 +19,7 @@ import numpy as np
 
 # ---- Local library imports
 from gwhat.meteo.weather_reader import WXDataFrameBase
-from gwhat.projet.reader_waterlvl import WLDataFrameBase
+from gwhat.projet.reader_waterlvl import WLDataFrameBase, WLDataset
 from gwhat.gwrecharge.glue import GLUEDataFrameBase
 from gwhat.common.utils import save_content_to_file
 from gwhat.utils.math import nan_as_text_tolist, calcul_rmse
@@ -222,10 +221,16 @@ class ProjetReader(object):
             grp = self.db['wldsets'].create_group(name)
 
             # Water level data
-            grp.create_dataset('Time', data=df['Time'])
-            grp.create_dataset('WL', data=df['WL'])
-            grp.create_dataset('BP', data=df['BP'])
-            grp.create_dataset('ET', data=df['ET'])
+            grp.create_dataset(
+                'Time',
+                data=np.array(df['Time'], dtype=h5py.special_dtype(vlen=str)))
+            # See http://docs.h5py.org/en/latest/strings.html as to why this
+            # is necessary to do this in order to save a list of strings in
+            # a dataset with h5py.
+
+            grp.create_dataset('WL', data=np.copy(df['WL']))
+            grp.create_dataset('BP', data=np.copy(df['BP']))
+            grp.create_dataset('ET', data=np.copy(df['ET']))
 
             # Piezometric well info
             grp.attrs['filename'] = df['filename']
@@ -378,8 +383,16 @@ class WLDataFrameHDF5(WLDataFrameBase):
     def __load_dataset__(self, hdf5group):
         self.dset = hdf5group
         self._undo_stack = []
-        self._waterlevels = self.dset['WL'][...]
-        self._datetimes = self.dset['Time'][...]
+
+        columns = []
+        data = []
+        for colname in ['Time', 'WL', 'BP', 'ET']:
+            if len(self.dset[colname][...]):
+                data.append(self.dset[colname][...])
+                columns.append(colname)
+        data = np.vstack(tuple(data)).transpose()
+        columns = tuple(columns)
+        self._dataf = WLDataset(data, columns)
 
         # Make older datasets compatible with newer format.
         if 'Well ID' not in list(self.dset.attrs.keys()):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -130,7 +130,7 @@ def read_water_level_datafile(filename):
         if colname in dataf.columns:
             dataf[colname] = pd.to_numeric(dataf[colname], errors='coerce')
 
-    # Format the dates to datetimes.
+    # Format the dates to datetimes and set it as index.
     try:
         # We assume first that the dates are stored in the
         # Excel numeric format.
@@ -275,6 +275,12 @@ def generate_HTML_table(name, lat, lon, alt, mun):
     table += '</table>'
 
     return table
+
+
+class EmptyWLDataset(pd.DataFrame):
+    def __init__(self):
+        super().__init__(np.empty((0, len(COLUMNS))), columns=COLUMNS)
+        self.set_index([INDEX], drop=True, inplace=True)
 
 
 class WLDataFrameBase(Mapping):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -408,9 +408,7 @@ class WLDataFrame(WLDataFrameBase):
 
     def __load_dataset__(self, filename):
         """Loads the dataset from a file and saves it in the store."""
-        self.dset = read_water_level_datafile(filename)
-        self._waterlevels = self.dset['WL']
-        self._datetimes = self.dset['Time']
+        self._dataf = read_water_level_datafile(filename)
 
 
 if __name__ == "__main__":

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -80,6 +80,8 @@ def read_water_level_datafile(filename):
     Load a water level dataset from a csv or an Excel file and format the
     data in a Pandas dataframe with the dates used as index.
     """
+    if filename is None or not osp.exists(filename):
+        return None
     reader = open_water_level_datafile(filename)
 
     # Fetch the header.

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -84,17 +84,14 @@ def read_water_level_datafile(filename):
         return None
     reader = open_water_level_datafile(filename)
 
-    # Fetch the header.
-    header = {'name': '', 'id': '', 'province': '', 'municipality': '',
-              'latitude': 0, 'longitude': 0, 'elevation': 0}
+    # Fetch the metadata from the header.
+    header = deepcopy(HEADER)
     for i, row in enumerate(reader):
         if not len(row):
             continue
-        label = str(row[0])
-        for key in header.keys():
-            regex = r'(?<!\S)' + key + r'(:|=)?(?!\S)'
-            key = 'elevation' if key == 'altitude' else key
-            if re.search(regex, label, re.IGNORECASE):
+        label = str(row[0]).replace(" ", "").replace("_", "")
+        for key in HEADER.keys():
+            if re.search(HEADER_REGEX[key], label, re.IGNORECASE):
                 if isinstance(header[key], (float, int)):
                     try:
                         header[key] = float(row[1])
@@ -104,7 +101,7 @@ def read_water_level_datafile(filename):
                     header[key] = str(row[1])
                 break
         else:
-            if re.search(r'(?<!\S)date(:|=)?(?!\S)', label, re.IGNORECASE):
+            if re.search(COL_REGEX[INDEX], label, re.IGNORECASE):
                 break
     else:
         print("ERROR: the water level datafile is not formatted correctly.")

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -40,11 +40,11 @@ COL_REGEX = OrderedDict([
     ])
 COLUMNS = list(COL_REGEX.keys())
 
-HEADER = {'Well Name': '', 'Well ID': '',
+HEADER = {'Well': '', 'Well ID': '',
           'Province': '', 'Municipality': '',
           'Latitude': 0, 'Longitude': 0, 'Elevation': 0}
 HEADER_REGEX = {
-    'Well Name': r'(?<!\S)(wellname|name)(:|=)?(?!\S)',
+    'Well': r'(?<!\S)(wellname|name)(:|=)?(?!\S)',
     'Well ID': r'(?<!\S)(wellid|id)(:|=)?(?!\S)',
     'Province': r'(?<!\S)(province|prov)(:|=)?(?!\S)',
     'Municipality': r'(?<!\S)municipality(:|=)?(?!\S)',

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -29,7 +29,8 @@ def open_water_level_datafile(filename):
     if ext not in FILE_EXTS:
         raise ValueError("Supported file format are: ", FILE_EXTS)
     else:
-        print('Loading waterlvl time-series from %s file...' % ext[1:])
+        print('Loading waterlvl time-series from "%s"...' %
+              osp.basename(filename))
 
     if ext == '.csv':
         with open(filename, 'r', encoding='utf8') as f:

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -8,12 +8,16 @@
 
 
 # ---- Standard library imports
+from copy import deepcopy
 import re
 import os
 import os.path as osp
 import numpy as np
 import xlrd
+from xlrd.xldate import xldate_from_datetime_tuple
+from xlrd import xldate_as_tuple
 import csv
+from collections import OrderedDict
 from collections.abc import Mapping
 
 # ---- Third party imports
@@ -26,6 +30,30 @@ FILE_EXTS = ['.csv', '.xls', '.xlsx']
 
 
 # ---- Read and Load Water Level Datafiles
+INDEX = 'Time'
+
+COL_REGEX = OrderedDict([
+    (INDEX, r'(date|time|datetime)'),
+    ('BP', r'(bp|baro|patm)'),
+    ('WL', r'(wl|waterlevels)'),
+    ('ET', r'(et|earthtides)')
+    ])
+COLUMNS = list(COL_REGEX.keys())
+
+HEADER = {'Well Name': '', 'Well ID': '',
+          'Province': '', 'Municipality': '',
+          'Latitude': 0, 'Longitude': 0, 'Elevation': 0}
+HEADER_REGEX = {
+    'Well Name': r'(?<!\S)(wellname|name)(:|=)?(?!\S)',
+    'Well ID': r'(?<!\S)(wellid|id)(:|=)?(?!\S)',
+    'Province': r'(?<!\S)(province|prov)(:|=)?(?!\S)',
+    'Municipality': r'(?<!\S)municipality(:|=)?(?!\S)',
+    'Latitude': r'(?<!\S)(latitude|lat)(:|=)?(?!\S)',
+    'Longitude': r'(?<!\S)(longitude|lon)(:|=)?(?!\S)',
+    'Elevation': r'(?<!\S)(elevation|elev|altitude|alt)(:|=)?(?!\S)'
+    }
+
+
 def open_water_level_datafile(filename):
     """Open a water level data file and return the data."""
     root, ext = os.path.splitext(filename)

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -251,9 +251,6 @@ def load_waterlvl_measures(filename, well):
     return time_mes, wl_mes
 
 
-# =========================================================================
-
-
 def generate_HTML_table(name, lat, lon, alt, mun):
 
     FIELDS = [['Well Name', name],

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -339,8 +339,9 @@ class WLDataFrameBase(Mapping):
 
     @property
     def waterlevels(self):
-        return self._waterlevels
+        return self.data['WL'].values
 
+    # ---- Versionning
     @property
     def has_uncommited_changes(self):
         """"
@@ -355,8 +356,8 @@ class WLDataFrameBase(Mapping):
     def undo(self):
         """Undo the last changes made to the water level data."""
         if self.has_uncommited_changes:
-            change = self._undo_stack.pop(-1)
-            self._waterlevels[change[0]] = change[1]
+            changes = self._undo_stack.pop(-1)
+            self._dataf['WL'][changes.index] = changes
 
     def clear_all_changes(self):
         """
@@ -370,7 +371,7 @@ class WLDataFrameBase(Mapping):
         """Delete the water level data at the specified indexes."""
         if len(indexes):
             self._add_to_undo_stack(indexes)
-            self._waterlevels[indexes] = np.nan
+            self._dataf['WL'].iloc[indexes] = np.nan
 
     def _add_to_undo_stack(self, indexes):
         """
@@ -379,7 +380,7 @@ class WLDataFrameBase(Mapping):
         changes made to the water level data before commiting them.
         """
         if len(indexes):
-            self._undo_stack.append((indexes, self.waterlevels[indexes]))
+            self._undo_stack.append(self._dataf['WL'].iloc[indexes].copy())
 
 
 class WLDataFrame(WLDataFrameBase):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -324,10 +324,14 @@ class WLDataFrameBase(Mapping):
         Return a numpy array containing the Excel numerical dates
         corresponding to the dates of the dataset.
         """
-        return np.array(
-            [xldate_from_datetime_tuple(date.timetuple()[:6], 0) for
-             date in self._dataf.index]
-            )
+        if 'XLDATES' not in self._dataf.columns:
+            print('Converting datetimes to xldates...', end=' ')
+            timedeltas = (
+                self._dataf.index - xlrd.xldate.xldate_as_datetime(4000, 0))
+            self._dataf['XLDATES'] = (
+                timedeltas.total_seconds()/(3600 * 24) + 4000)
+            print('done')
+        return self._dataf['XLDATES'].values
 
     @property
     def dates(self):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -54,6 +54,11 @@ HEADER_REGEX = {
     }
 
 
+class EmptyWLDataset(pd.DataFrame):
+    def __init__(self):
+        super().__init__(np.empty((0, len(COLUMNS))), columns=COLUMNS)
+        self.set_index([INDEX], drop=True, inplace=True)
+
 def open_water_level_datafile(filename):
     """Open a water level data file and return the data."""
     root, ext = os.path.splitext(filename)
@@ -272,12 +277,6 @@ def generate_HTML_table(name, lat, lon, alt, mun):
     table += '</table>'
 
     return table
-
-
-class EmptyWLDataset(pd.DataFrame):
-    def __init__(self):
-        super().__init__(np.empty((0, len(COLUMNS))), columns=COLUMNS)
-        self.set_index([INDEX], drop=True, inplace=True)
 
 
 class WLDataFrameBase(Mapping):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -298,8 +298,7 @@ class WLDataFrameBase(Mapping):
         super().__init__(*args, **kwargs)
         self.dset = None
         self._undo_stack = []
-        self._waterlevels = np.array([])
-        self._datetimes = np.array([])
+        self._dataf = EmptyWLDataset()
 
     def __load_dataset__(self):
         """Loads the dataset and save it in a store."""
@@ -314,10 +313,29 @@ class WLDataFrameBase(Mapping):
     def __iter__(self):
         return NotImplementedError
 
-    # ---- Water levels
+    # ---- Attributes
     @property
-    def datetimes(self):
-        return self._datetimes
+    def data(self):
+        return self._dataf
+
+    @property
+    def xldates(self):
+        """
+        Return a numpy array containing the Excel numerical dates
+        corresponding to the dates of the dataset.
+        """
+        return np.array(
+            [xldate_from_datetime_tuple(date.timetuple()[:6], 0) for
+             date in self._dataf.index]
+            )
+
+    @property
+    def dates(self):
+        return self.data.index.values
+
+    @property
+    def strftime(self):
+        return self.data.index.strftime("%Y-%m-%dT%H:%M:%S").values.tolist()
 
     @property
     def waterlevels(self):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -104,7 +104,7 @@ def read_water_level_datafile(filename):
     # Format the data to floats.
     for colname in ['BP(m)', 'WL(mbgs)', 'ET(nm/s2)']:
         if colname in dataf.columns:
-            dataf[colname] = dataf[colname].astype('float64', errors='ignore')
+            dataf[colname] = pd.to_numeric(dataf[colname], errors='coerce')
 
     # Format the dates to datetimes.
     try:

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -384,7 +384,10 @@ class WLDataFrameBase(Mapping):
 
 
 class WLDataFrame(WLDataFrameBase):
-    """A water level dataset container that loads its data from a file."""
+    """
+    A water level dataset container that loads its data from a csv
+    or an Excel file.
+    """
 
     def __init__(self, filename, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -392,6 +395,15 @@ class WLDataFrame(WLDataFrameBase):
 
     def __getitem__(self, key):
         """Returns the value saved in the store at key."""
+        if key == INDEX:
+            return self.strftime
+        elif key in COLUMNS:
+            return self.data[key].values
+        elif key in list(HEADER.keys()):
+            return getattr(self._dataf, key, HEADER[key])
+        elif key == 'filename':
+            return self._dataf.filename
+
         return self.dset.__getitem__(key)
 
     def __load_dataset__(self, filename):

--- a/gwhat/tests/test_read_waterlvl.py
+++ b/gwhat/tests/test_read_waterlvl.py
@@ -10,6 +10,7 @@
 import sys
 import os
 import os.path as osp
+import csv
 
 # ---- Third party imports
 import pytest
@@ -65,7 +66,7 @@ def test_reading_waterlvl(ext):
     keys = ['Well', 'Well ID', 'Province', 'Latitude', 'Longitude',
             'Elevation', 'Municipality']
     for key in keys:
-        assert df1[key] == expected_results[key]
+        assert df[key] == expected_results[key]
 
 
 # Test water_level_measurements.*

--- a/gwhat/tests/test_read_waterlvl.py
+++ b/gwhat/tests/test_read_waterlvl.py
@@ -6,28 +6,27 @@
 # This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
 # Licensed under the terms of the GNU General Public License.
 
-# Standard library imports
+# ---- Standard library imports
 import sys
 import os
-import csv
+import os.path as osp
 
-# Third party imports
+# ---- Third party imports
 import pytest
 import numpy as np
 import xlsxwriter
 
-# Local imports
-sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+# ---- Local library imports
 from gwhat.common.utils import (save_content_to_excel, save_content_to_csv,
                                 delete_file)
 from gwhat.projet.reader_waterlvl import (
-        load_waterlvl_measures, init_waterlvl_measures,
-        read_water_level_datafile)
+        load_waterlvl_measures, init_waterlvl_measures, WLDataFrame)
 
 
 # Test reading water level datafiles
 # ----------------------------------
 
+DATADIR = osp.join(osp.dirname(osp.realpath(__file__)))
 DATA = [['Well name = ', "êi!@':i*"],
         ['well id : ', '1234ABC'],
         ['Province', 'Qc'],
@@ -41,18 +40,14 @@ DATA = [['Well name = ', "êi!@':i*"],
         [41241.70833, 3.665777025, 10.33127437, 387.7404819],
         [41241.71875, 3.665277031, 10.33097437, 396.9950643]
         ]
-save_content_to_csv("water_level_datafile.csv", DATA)
-save_content_to_excel("water_level_datafile.xls", DATA)
-save_content_to_excel("water_level_datafile.xlsx", DATA)
+save_content_to_csv(osp.join(DATADIR, "water_level_datafile.csv"), DATA)
+save_content_to_excel(osp.join(DATADIR, "water_level_datafile.xls"), DATA)
+save_content_to_excel(osp.join(DATADIR, "water_level_datafile.xlsx"), DATA)
 
 
-def test_reading_waterlvl():
-    df1 = read_water_level_datafile("water_level_datafile.csv")
-    df2 = read_water_level_datafile("water_level_datafile.xls")
-    df3 = read_water_level_datafile("water_level_datafile.xlsx")
-
-    assert list(df1.keys()) == list(df2.keys())
-    assert list(df2.keys()) == list(df3.keys())
+@pytest.mark.parametrize("ext", ['.csv', '.xls', '.xlsx'])
+def test_reading_waterlvl(ext):
+    df = WLDataFrame(osp.join(DATADIR, "water_level_datafile" + ext))
 
     expected_results = {
           'Well': "êi!@':i*",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib>=2.0.2
 requests
 h5py>=2.8
 qtawesome
+pandas


### PR DESCRIPTION
The idea is to use a pandas `DataFrame` to manage the water levels, barometric and earth tide data. This is going to make the manipulation of the time series so much easier.

Morever, time is now tracked as `datetime` objects and saved as strings. Therefore, it is going to provide a mean to fix all the bugs that occur when data are available before year 1900. If this works well, the same approach will be used to manage weather data too.