### PR TITLE
PR: Use a more efficient method to calculate horizontal distance and remove code duplication

### DIFF
--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -431,27 +431,27 @@ class HydroprintGUI(myqt.DialogWindow):
             self.clear_hydrograph()
             return
         else:
-            wldset = self.wldset
-            self.hydrograph.set_wldset(wldset)
+            self.hydrograph.set_wldset(self.wldset)
             self.hydrograph.gluedf = self.wldset.get_glue_at(-1)
 
         # Load the manual measurements.
 
-        fname = os.path.join(self.workdir, "Water Levels",
-                             'waterlvl_manual_measurements')
-        tmeas, wlmeas = load_waterlvl_measures(fname, wldset['Well'])
-        wldset.set_wlmeas(tmeas, wlmeas)
+        fname = os.path.join(
+            self.workdir, "Water Levels", 'waterlvl_manual_measurements')
+        tmeas, wlmeas = load_waterlvl_measures(fname, self.wldset['Well'])
+        self.wldset.set_wlmeas(tmeas, wlmeas)
 
         # Setup the layout of the hydrograph.
 
-        layout = wldset.get_layout()
+        layout = self.wldset.get_layout()
         if layout is not None:
-            msg = 'Loading existing graph layout for well %s.' % wldset['Well']
+            msg = ("Loading existing graph layout for well %s." %
+                   self.wldset['Well'])
             print(msg)
             self.ConsoleSignal.emit('<font color=black>%s</font>' % msg)
             self.load_graph_layout(layout)
         else:
-            print('No graph layout exists for well %s.' % wldset['Well'])
+            print('No graph layout exists for well %s.' % self.wldset['Well'])
             # Fit Water Level in Layout :
             self.__updateUI = False
             self.best_fit_waterlvl()

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -29,7 +29,7 @@ from xlrd.xldate import xldate_from_date_tuple
 from xlrd import xldate_as_tuple
 
 # ---- Local imports
-
+from gwhat.common.utils import calc_dist_from_coord
 from gwhat.colors2 import ColorsReader
 
 mpl.rc('font', **{'family': 'sans-serif', 'sans-serif': ['Arial']})
@@ -374,8 +374,9 @@ class Hydrograph(Figure):
         # Calculate horizontal distance between weather station and
         # observation well.
         if self.wxdset is not None:
-            self.dist = LatLong2Dist(wldset['Latitude'], wldset['Longitude'],
-                                     wxdset['Latitude'], wxdset['Longitude'])
+            self.dist = calc_dist_from_coord(
+                wldset['Latitude'], wldset['Longitude'],
+                wxdset['Latitude'], wxdset['Longitude'])
         else:
             self.dist = 0
 
@@ -1240,46 +1241,6 @@ def filt_data(time, waterlvl, N):
     tf = days[N//2:-N//2+1]
 
     return tf, wlf
-
-
-def LatLong2Dist(LAT1, LON1, LAT2, LON2):
-    """
-    Computes the horizontal distance in km between 2 points from geographic
-    coordinates given in decimal degrees.
-
-    ---- INPUT ----
-
-    LAT1 = latitute coordinate of first point
-    LON1 = longitude coordinate of first point
-    LAT2 = latitude coordinate of second point
-    LON2 = longitude coordinate of second point
-
-    ---- OUTPUT ----
-
-    DIST = horizontal distance between the two points in km
-
-    ---- SOURCE ----
-
-    www.stackoverflow.com/questions/19412462 (last accessed on 17/01/2014)
-    """
-
-    R = 6373.0  # R = Earth radius in km
-
-    # Convert decimal degrees to radians.
-    LAT1 = radians(LAT1)
-    LON1 = radians(LON1)
-    LAT2 = radians(LAT2)
-    LON2 = radians(LON2)
-
-    # Compute the horizontal distance between the two points in km.
-    dLON = LON2 - LON1
-    dLAT = LAT2 - LAT1
-    a = (sin(dLAT/2))**2 + cos(LAT1) * cos(LAT2) * (sin(dLON/2))**2
-    c = 2 * atan2(sqrt(a), sqrt(1-a))
-
-    DIST = R * c
-
-    return DIST
 
 
 if __name__ == '__main__':

--- a/gwhat/meteo/gapfill_weather_algorithm2.py
+++ b/gwhat/meteo/gapfill_weather_algorithm2.py
@@ -35,7 +35,7 @@ from PyQt5.QtCore import QObject
 # ---- Local imports
 
 from gwhat.common.utils import save_content_to_csv
-from gwhat.hydrograph4 import LatLong2Dist
+from gwhat.common.utils import calc_dist_from_coord
 from gwhat.meteo.weather_viewer import FigWeatherNormals
 from gwhat.meteo.gapfill_weather_postprocess import PostProcessErr
 import gwhat.meteo.weather_reader as wxrd
@@ -1234,37 +1234,26 @@ class TargetStationInfo(object):
         # a 0 value at index <index>
 
 
-# =============================================================================
-
-
 def alt_and_dist_calc(WEATHER, index):
     """
-    Computes the horizontal distance in km and the altitude difference
-    in m between the target station and each neighboring stations
+    Compute the horizontal distances in km and the altitude differences
+    in m between the target station and each neighboring station.
 
     index: Target Station Index
     """
+    alt = np.array(WEATHER.ALT)
+    lat = np.array(WEATHER.LAT)
+    lon = np.array(WEATHER.LON)
 
-    ALT = WEATHER.ALT
-    LAT = WEATHER.LAT
-    LON = WEATHER.LON
+    # Calcul horizontal and vertical distances of neighboring stations
+    # from target.
+    hordist = calc_dist_from_coord(lat[index], lon[index], lat, lon)
+    altdiff = alt - alt[index]
 
-    nSTA = len(ALT)  # number of stations including target
+    hordist = np.round(hordist, 1)
+    altdiff = np.round(altdiff, 1)
 
-    HORDIST = np.zeros(nSTA)  # distances of neighboring station from target
-    ALTDIFF = np.zeros(nSTA)  # altitude differences
-
-    for i in range(nSTA):
-        HORDIST[i] = LatLong2Dist(LAT[index], LON[index], LAT[i], LON[i])
-        ALTDIFF[i] = ALT[i] - ALT[index]
-
-    HORDIST = np.round(HORDIST, 1)
-    ALTDIFF = np.round(ALTDIFF, 1)
-
-    return HORDIST, ALTDIFF
-
-
-# =============================================================================
+    return hordist, altdiff
 
 
 class WeatherData(object):

--- a/gwhat/meteo/gapfill_weather_gui.py
+++ b/gwhat/meteo/gapfill_weather_gui.py
@@ -1609,11 +1609,6 @@ if __name__ == '__main__':
 #    stamap.plot_obswells(GWSU24[0], GWSU24[1], 'GW-SU-24')
 #    stamap.plot_obswells(GWSU34[0], GWSU34[1], 'GW-SU-34')
 #    stamap.show()
-#
-#    print()
-#    from hydrograph3 import LatLong2Dist
-#    for x, y, n, a in zip(lat, lon, name, alt):
-#        print(n, LatLong2Dist(x, y, GWSU16[0], GWSU16[1]))
 
     # ---- Show and Move Center ----
 

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -732,6 +732,7 @@ class WXDataFrameHDF5(WXDataFrameBase):
     This is a wrapper around the h5py group to read the weather data
     from the project.
     """
+
     def __init__(self, dataset, *args, **kwargs):
         super(WXDataFrameHDF5, self).__init__(*args, **kwargs)
         self.__load_dataset__(dataset)
@@ -782,6 +783,7 @@ class GLUEDataFrameHDF5(GLUEDataFrameBase):
     This is a wrapper around the h5py group to read the GLUE results
     from the project.
     """
+
     def __init__(self, data, *args, **kwargs):
         super(GLUEDataFrameHDF5, self).__init__(*args, **kwargs)
         self.__load_data__(data)


### PR DESCRIPTION
Two methods exists in GWHAT codebase to calculate the horizontal distance from lat/lon coordinates. One is using a Python loop, while the other one uses numpy and is way more faster and efficient.

So the idea is to use the more efficient function everywhere and remove code duplication.