### PR TITLE
PR: Force a redrawing of the water levels when clearing the selections

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -338,7 +338,8 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
         self.btn_clear_select = QToolButtonNormal('rect_select_clear')
         self.btn_clear_select.setToolTip("Clear selected water levels.")
-        self.btn_clear_select.clicked.connect(self.clear_selected_wl)
+        self.btn_clear_select.clicked.connect(
+            lambda: self.clear_selected_wl(draw=True))
 
         self.btn_del_select = QToolButtonNormal('erase_data')
         self.btn_del_select.setToolTip(


### PR DESCRIPTION
The button to clear water level selection was not forcing a redrawing of the plot when clicked on.

![image](https://user-images.githubusercontent.com/10170372/55969844-76170200-5c4c-11e9-8b63-11879cca243a.png)
