### PR TITLE
PR: Prevent GWHAT from crashing when trying to set weather data to the closest station from the well if no weather data are available.

### DIFF
--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -437,7 +437,7 @@ class DataManager(QWidget):
         Set the weather dataset of the station that is closest to the
         groundwater observation well.
         """
-        if self.wldataset_count() == 0:
+        if self._wldset is None or self.wxdataset_count() == 0:
             return
 
         dist = calc_dist_from_coord(self._wldset['Latitude'],


### PR DESCRIPTION
GWHAT was crashing when trying to set the weather data to the data from the closest station when there was no weather data stored in the project.