### PR TITLE
PR: Prevent crash when plotting BRF results in BRFFigure if ymin and ymax are inf

### DIFF
--- a/gwhat/brf_mod/kgs_plot.py
+++ b/gwhat/brf_mod/kgs_plot.py
@@ -143,7 +143,7 @@ class BRFFigure(mpl.figure.Figure):
                 ymin = min(np.floor(np.min(A)/0.2)*0.2, 0)
         else:
             ymin = ylim[0]
-        ymin = max(-5, ymin)
+        ymin = max(-10, ymin)
 
         if ylim[1] is None:
             if len(err) > 0:
@@ -152,7 +152,7 @@ class BRFFigure(mpl.figure.Figure):
                 ymax = max(np.ceil(np.max(A)/0.2)*0.2, 1)
         else:
             ymax = ylim[1]
-        ymax = min(5, ymax)
+        ymax = min(10, ymax)
 
         # ---- Setup xticks and yticks
         yscl = 0.2 if yscl is None else yscl

--- a/gwhat/brf_mod/kgs_plot.py
+++ b/gwhat/brf_mod/kgs_plot.py
@@ -143,6 +143,7 @@ class BRFFigure(mpl.figure.Figure):
                 ymin = min(np.floor(np.min(A)/0.2)*0.2, 0)
         else:
             ymin = ylim[0]
+        ymin = max(-5, ymin)
 
         if ylim[1] is None:
             if len(err) > 0:
@@ -151,9 +152,9 @@ class BRFFigure(mpl.figure.Figure):
                 ymax = max(np.ceil(np.max(A)/0.2)*0.2, 1)
         else:
             ymax = ylim[1]
+        ymax = min(5, ymax)
 
-        # ---- Xticks ans Yticks Setup
-
+        # ---- Setup xticks and yticks
         yscl = 0.2 if yscl is None else yscl
         ax.set_yticks(np.arange(ymin, ymax+yscl, yscl))
 


### PR DESCRIPTION
Sometimes, bad BRF results can have a minimum and maximum value of -inf or inf. This causes the plotting of those results to crash when trying to set the limits of the y-axis.

The idea is then to limit the minimum and maximum value for the y-axis to -10 and 10. These values reflect also the range of possible values that the user can select in the GUI.