### PR TITLE
PR: Remove logging of errors in GWHAT

### DIFF
--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -353,13 +353,5 @@ class WHATPref(object):
 # %% if __name__ == '__main__'
 
 if __name__ == '__main__':
-    import logging
-
-    logging.basicConfig(filename='WHAT.log', level=logging.DEBUG,
-                        format='%(asctime)s - %(levelname)s:%(message)s')
-    try:
-        main = MainWindow()
-        sys.exit(app.exec_())
-    except Exception as e:
-        logging.exception(str(e))
-        raise e
+    main = MainWindow()
+    sys.exit(app.exec_())


### PR DESCRIPTION
This is useless to me for the moment and I do not have the time to maintain and improve this feature. So might as well be better to simply remove this.