### PR TITLE
PR: Improve wldsets and wxdsets GUI response

### DIFF
--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -123,7 +123,6 @@ class DataManager(QWidget):
         # ---- Toolbar
 
         self.wxdsets_cbox = QComboBox()
-        self.wxdsets_cbox.currentIndexChanged.connect(self.update_wxdset_info)
         self.wxdsets_cbox.currentIndexChanged.connect(self.wxdset_changed)
 
         self.btn_load_meteo = QToolButtonSmall(icons.get_icon('importFile'))
@@ -188,8 +187,6 @@ class DataManager(QWidget):
         if projet is not None:
             self.update_wldsets(projet.get_last_opened_wldset())
             self.update_wxdsets(projet.get_last_opened_wxdset())
-            self.update_wxdset_info()
-
             self.wldset_changed()
 
         self.btn_export_weather.set_model(self.get_current_wxdset())
@@ -357,7 +354,6 @@ class DataManager(QWidget):
         print("Saving the new weather dataset in the project.", end=" ")
         self.projet.add_wxdset(name, dataset)
         self.update_wxdsets(name)
-        self.update_wxdset_info()
         self.wxdset_changed()
         print("done")
 
@@ -385,6 +381,8 @@ class DataManager(QWidget):
 
     def wxdset_changed(self):
         """Handle when the currently selected weather dataset changed."""
+        QApplication.processEvents()
+        self.update_wxdset_info()
         self.btn_export_weather.set_model(self.get_current_wxdset())
         self.wxdsetChanged.emit(self.get_current_wxdset())
 
@@ -402,7 +400,6 @@ class DataManager(QWidget):
             self._wxdset = None
             self.projet.del_wxdset(dsetname)
             self.update_wxdsets()
-            self.update_wxdset_info()
             self.wxdset_changed()
             self.sig_new_console_msg.emit((
                 "<font color=black>Weather dataset <i>{}</i> deleted "
@@ -423,8 +420,6 @@ class DataManager(QWidget):
         self.wxdsets_cbox.blockSignals(True)
         self.wxdsets_cbox.setCurrentIndex(self.wxdsets_cbox.findText(name))
         self.wxdsets_cbox.blockSignals(False)
-
-        self.update_wxdset_info()
         self.wxdset_changed()
 
     def set_closest_wxdset(self):

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -87,7 +87,6 @@ class DataManager(QWidget):
         # ---- Toolbar
 
         self.wldsets_cbox = QComboBox()
-        self.wldsets_cbox.currentIndexChanged.connect(self.update_wldset_info)
         self.wldsets_cbox.currentIndexChanged.connect(self.wldset_changed)
 
         self.btn_load_wl = QToolButtonSmall(icons.get_icon('importFile'))
@@ -189,8 +188,6 @@ class DataManager(QWidget):
         if projet is not None:
             self.update_wldsets(projet.get_last_opened_wldset())
             self.update_wxdsets(projet.get_last_opened_wxdset())
-
-            self.update_wldset_info()
             self.update_wxdset_info()
 
             self.wldset_changed()
@@ -261,7 +258,6 @@ class DataManager(QWidget):
         print("Saving the new water level dataset in the project...", end=" ")
         self.projet.add_wldset(name, dataset)
         self.update_wldsets(name)
-        self.update_wldset_info()
         self.wldset_changed()
         print("done")
 
@@ -290,6 +286,8 @@ class DataManager(QWidget):
 
     def wldset_changed(self):
         """Handle when the currently selected water level dataset changed."""
+        QApplication.processEvents()
+        self.update_wldset_info()
         self.wldsetChanged.emit(self.get_current_wldset())
 
     def get_current_wldset(self):
@@ -307,8 +305,6 @@ class DataManager(QWidget):
         self.wldsets_cbox.blockSignals(True)
         self.wldsets_cbox.setCurrentIndex(self.wldsets_cbox.findText(name))
         self.wldsets_cbox.blockSignals(False)
-
-        self.update_wldset_info()
         self.wldset_changed()
 
     def del_current_wldset(self):
@@ -325,7 +321,6 @@ class DataManager(QWidget):
             self._wldset = None
             self.projet.del_wldset(dsetname)
             self.update_wldsets()
-            self.update_wldset_info()
             self.wldset_changed()
             self.sig_new_console_msg.emit((
                 "<font color=black>Water level dataset <i>{}</i> deleted "


### PR DESCRIPTION
When changing either the water level or weather dataset with one of the dropbox menu, there is a delay between the time when the action is performed and the time when the selection appears in the dropdown menu. This delay is due to the time required to load and plot the dataset, which can be a couple of seconds in cases of large datasets.

The goal of this PR is to make both dropdown menus appear to be more responsive, so that the user knows that his action were registered by the software.

![image](https://user-images.githubusercontent.com/10170372/55987211-fcdcd680-5c6e-11e9-9a08-5305bd5d1e25.png)
