### PR TITLE
PR: Set wldset and wxdset to None when project change to avoid a crash

### DIFF
--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -184,6 +184,8 @@ class DataManager(QWidget):
     def set_projet(self, projet):
         """Set the namespace for the projet hdf5 file."""
         self._projet = projet
+        self._wldset = None
+        self._wxdset = None
         if projet is not None:
             self.update_wldsets(projet.get_last_opened_wldset())
             self.update_wxdsets(projet.get_last_opened_wxdset())


### PR DESCRIPTION
This PR fixes the following error that happens when switching project. This was introduced in  PR #277.

```python
Traceback (most recent call last):
  File "C:\Users\User\gwhat\gwhat\projet\manager_data.py", line 190, in set_projet
    self.wldset_changed()
  File "C:\Users\User\gwhat\gwhat\projet\manager_data.py", line 287, in wldset_changed
    self.update_wldset_info()
  File "C:\Users\User\gwhat\gwhat\projet\manager_data.py", line 271, in update_wldset_info
    wldset = self.get_current_wldset()
  File "C:\Users\User\gwhat\gwhat\projet\manager_data.py", line 296, in get_current_wldset
    if self._wldset is None or self._wldset.name != cbox_text:
  File "C:\Users\User\gwhat\gwhat\projet\reader_projet.py", line 451, in name
    return osp.basename(self.dset.name)
  File "C:\Anaconda3\envs\pyhelp-dev\lib\ntpath.py", line 236, in basename
    return split(p)[1]
  File "C:\Anaconda3\envs\pyhelp-dev\lib\ntpath.py", line 205, in split
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```