### PR TITLE
PR: Force a redraw of the hydrograph if wxdset is None after setting the wxdset to that of the closest station from the well.

### DIFF
--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -456,7 +456,8 @@ class HydroprintGUI(myqt.DialogWindow):
             self.__updateUI = False
             self.best_fit_waterlvl()
             self.best_fit_time()
-            self.dmngr.set_closest_wxdset()
+            if self.dmngr.set_closest_wxdset() is None:
+                self.draw_hydrograph()
             self.__updateUI = True
 
     def wxdset_changed(self):
@@ -469,7 +470,6 @@ class HydroprintGUI(myqt.DialogWindow):
             self.draw_hydrograph()
 
     # ---- Draw Hydrograph Handlers
-
     def best_fit_waterlvl(self):
         wldset = self.dmngr.get_current_wldset()
         if wldset is not None:

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -777,8 +777,8 @@ class HydroprintGUI(myqt.DialogWindow):
         if layout['wxdset'] in self.dmngr.wxdsets:
             self.dmngr.set_current_wxdset(layout['wxdset'])
         else:
-            self.dmngr.set_closest_wxdset()
-
+            if self.dmngr.set_closest_wxdset() is None:
+                self.draw_hydrograph()
         self.__updateUI = True
 
     def save_layout_isClicked(self):


### PR DESCRIPTION
The changes made in PR #280 introduced a bug where the Hydrograph was not refreshing when no weather dataset were selected during the operation of setting the weather dataset of the station closest to the well.