### PR TITLE
PR: Fix saving project location when project is saved on another drive than that where GWHAT is installed

### DIFF
--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -306,6 +306,9 @@ class WHATPref(object):
         self.load_pref_file()
 
     def save_pref_file(self):
+        """
+        Save the GWHAT user preferences to file.
+        """
         print('\n\rSaving WHAT preferences to file...', end=' ')
         try:
             fpath = osp.relpath(self.projectfile)

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -307,7 +307,15 @@ class WHATPref(object):
 
     def save_pref_file(self):
         print('\nSaving WHAT preferences to file...')
-        fcontent = [['Project File:', os.path.relpath(self.projectfile)],
+        try:
+            fpath = osp.relpath(self.projectfile)
+        except ValueError:
+            # This probably means that the gwhat project is not saved on the
+            # same drive as the one where GHWAT is installed.
+            # See jnsebgosselin/gwhat#289.
+            fpath = osp.abspath(self.projectfile)
+
+        fcontent = [['Project File:', fpath],
                     ['Language:', self.language],
                     ['Font-Size-General:', self.fontsize_general],
                     ['Font-Size-Console:', self.fontsize_console],

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -294,7 +294,7 @@ class WHATPref(object):
               of graphs).
     """
 
-    def __init__(self, parent=None):  # =======================================
+    def __init__(self, parent=None):
 
         self.projectfile = os.path.join(
             '..', 'Projects', 'Example', 'Example.gwt')
@@ -306,7 +306,7 @@ class WHATPref(object):
         self.load_pref_file()
 
     def save_pref_file(self):
-        print('\nSaving WHAT preferences to file...')
+        print('\n\rSaving WHAT preferences to file...', end=' ')
         try:
             fpath = osp.relpath(self.projectfile)
         except ValueError:
@@ -321,7 +321,7 @@ class WHATPref(object):
                     ['Font-Size-Console:', self.fontsize_console],
                     ['Font-Size-Menubar:', self.fontsize_menubar]]
         save_content_to_csv('WHAT.pref', fcontent)
-        print('WHAT preferences saved.')
+        print('done')
 
     def load_pref_file(self, circloop=False):
 


### PR DESCRIPTION
Fixes #289

The idea is to try to save the relative path, but save the absolute path if a `ValueError` is thrown.