### PR TITLE
PR: Fix matplotlib imports for version 3.1 and numpy load function

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -25,7 +25,7 @@ from PyQt5.QtWidgets import (
 
 import matplotlib as mpl
 import matplotlib.dates as mdates
-from matplotlib.figure import Figure
+from matplotlib.figure import Figure as MplFigure
 from matplotlib.patches import Rectangle
 from matplotlib.transforms import ScaledTranslation
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
@@ -121,7 +121,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
         # ---- Setup the canvas
 
-        self.fig = Figure(facecolor='white')
+        self.fig = MplFigure(facecolor='white')
         self.canvas = FigureCanvasQTAgg(self.fig)
 
         self.canvas.mpl_connect('button_press_event', self.onclick)

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -16,7 +16,6 @@ import datetime
 
 # ---- Third party imports
 import numpy as np
-from matplotlib.patches import Rectangle
 from PyQt5.QtCore import Qt
 from PyQt5.QtCore import pyqtSlot as QSlot
 from PyQt5.QtCore import pyqtSignal as QSignal
@@ -25,6 +24,10 @@ from PyQt5.QtWidgets import (
     QTabWidget, QApplication, QWidget)
 
 import matplotlib as mpl
+import matplotlib.dates as mdates
+from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
+from matplotlib.transforms import ScaledTranslation
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 
@@ -118,7 +121,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
         # ---- Setup the canvas
 
-        self.fig = mpl.figure.Figure(facecolor='white')
+        self.fig = Figure(facecolor='white')
         self.canvas = FigureCanvasQTAgg(self.fig)
 
         self.canvas.mpl_connect('button_press_event', self.onclick)
@@ -237,8 +240,7 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
         # x and y coorrdinate labels displayed at the right-bottom corner
         # of the graph
-        offset = mpl.transforms.ScaledTranslation(
-            -5/72, 5/72, self.fig.dpi_scale_trans)
+        offset = ScaledTranslation(-5/72, 5/72, self.fig.dpi_scale_trans)
         self.xycoord = ax0.text(
             1, 0, '', ha='right', transform=ax0.transAxes + offset)
         self.xycoord.set_visible(False)

--- a/gwhat/brf_mod/kgs_plot.py
+++ b/gwhat/brf_mod/kgs_plot.py
@@ -11,7 +11,8 @@
 
 # ---- Imports: third parties
 
-import matplotlib as mpl
+from matplotlib.transforms import ScaledTranslation
+from matplotlib.figure import Figure
 import numpy as np
 
 
@@ -31,7 +32,7 @@ class FigureLabels(object):
             self.title = ('Well %s from %s to %s')
 
 
-class BRFFigure(mpl.figure.Figure):
+class BRFFigure(Figure):
     def __init__(self, lang='English'):
         super(BRFFigure, self).__init__()
         lang = lang if lang.lower() in FigureLabels.LANGUAGES else 'English'
@@ -77,8 +78,7 @@ class BRFFigure(mpl.figure.Figure):
 
         self.errbar, = ax.plot([], [])
 
-        offset = mpl.transforms.ScaledTranslation(
-                0, -5/72, self.dpi_scale_trans)
+        offset = ScaledTranslation(0, -5/72, self.dpi_scale_trans)
 
         self.title = ax.text(0.5, 1, '', ha='center', va='top', fontsize=14,
                              transform=ax.transAxes+offset)

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -18,7 +18,7 @@ from xlrd.xldate import xldate_from_date_tuple
 import numpy as np
 import matplotlib as mpl
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
-from matplotlib.figure import Figure as MPLFigure
+from matplotlib.figure import Figure as MplFigure
 
 from PyQt5.QtCore import Qt, QEvent
 from PyQt5.QtCore import pyqtSlot as QSlot
@@ -741,7 +741,7 @@ class FigCanvasBase(FigureCanvasQTAgg):
     This is the base figure format to plot GLUE results.
     """
     FIGNAME = "figure_name"
-    sig_fig_changed = QSignal(MPLFigure)
+    sig_fig_changed = QSignal(MplFigure)
     sig_newfig_plotted = QSignal(dict)
 
     colors = {'dark grey': '0.65',
@@ -751,7 +751,7 @@ class FigCanvasBase(FigureCanvasQTAgg):
     MARGINS = [1, 0.15, 0.15, 0.65]  # left, top, right, bottom
 
     def __init__(self, setp={}):
-        super(FigCanvasBase, self).__init__(mpl.figure.Figure())
+        super(FigCanvasBase, self).__init__(MplFigure())
         self.xticklabels = []
         self.notes = []
         self._xticklabels_yt = 0

--- a/gwhat/meteo/gapfill_weather_gui.py
+++ b/gwhat/meteo/gapfill_weather_gui.py
@@ -32,7 +32,7 @@ from PyQt5.QtWidgets import (QWidget, QPushButton, QGridLayout, QFrame,
 import numpy as np
 from xlrd.xldate import xldate_from_date_tuple
 from xlrd import xldate_as_tuple
-import matplotlib as mpl
+from matplotlib.figure import Figure as MplFigure
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 
@@ -826,7 +826,7 @@ class StaLocManager(QWidget):
     def __init__(self, *args, **kwargs):
         super(StaLocManager, self).__init__(*args, **kwargs)
 
-        self.figure = mpl.figure.Figure()
+        self.figure = MplFigure()
         self.canvas = FigureCanvasQTAgg(self.figure)
         toolbar = NavigationToolbar2QT(self.canvas, self)
 

--- a/gwhat/meteo/gapfill_weather_postprocess.py
+++ b/gwhat/meteo/gapfill_weather_postprocess.py
@@ -8,13 +8,12 @@
 
 
 # ---- Standard Library Imports
-
 import csv
 import os
 
 # ---- Third Party Imports
-
-import matplotlib as mpl
+from matplotlib.figure import Figure as MplFigure
+from matplotlib.transforms import ScaledTranslation
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 
 import numpy as np
@@ -23,7 +22,6 @@ from scipy.stats._continuous_distns import gamma
 from xlrd.xldate import xldate_from_date_tuple
 
 # ---- Local Library Imports
-
 from gwhat.common.utils import save_content_to_csv
 
 
@@ -231,7 +229,7 @@ def plot_est_err(Ymes, Ypre, varName, fname, language='English'):
     Ymin = np.floor(np.min(Ymes)/10)*10
 
     fw, fh = 6, 6
-    fig = mpl.figure.Figure(figsize=(fw, fh))
+    fig = MplFigure(figsize=(fw, fh))
     canvas = FigureCanvas(fig)
 
     # ---- Create Axes
@@ -303,8 +301,7 @@ def plot_est_err(Ymes, Ypre, varName, fname, language='English'):
     tcontent = list(reversed(tcontent))
     for i in range(len(tcontent)):
         dx, dy = -10 / 72., 10 * (i+1) / 72.
-        padding = mpl.transforms.ScaledTranslation(dx, dy,
-                                                   fig.dpi_scale_trans)
+        padding = ScaledTranslation(dx, dy, fig.dpi_scale_trans)
         transform = ax0.transAxes + padding
         ax0.text(0, 0, tcontent[i], ha='left', va='bottom', fontsize=16,
                  transform=transform)
@@ -387,7 +384,7 @@ def plot_est_err(Ymes, Ypre, varName, fname, language='English'):
 def plot_gamma_dist(Ymes, Ypre, fname, language='English'):
 
     fw, fh = 6, 6
-    fig = mpl.figure.Figure(figsize=(fw, fh), facecolor='white')
+    fig = MplFigure(figsize=(fw, fh), facecolor='white')
     canvas = FigureCanvas(fig)
 
     # ---- Create Axes
@@ -504,7 +501,7 @@ def plot_gamma_dist(Ymes, Ypre, fname, language='English'):
     bbox = bbox.transformed(ax0.transAxes.inverted())
 
     dx, dy = 5/72., 5/72.
-    padding = mpl.transforms.ScaledTranslation(dx, dy, fig.dpi_scale_trans)
+    padding = ScaledTranslation(dx, dy, fig.dpi_scale_trans)
     transform = ax0.transAxes + padding
 
     ax0.text(0., 0., msg, transform=transform, va='bottom', ha='left')
@@ -518,7 +515,7 @@ def plot_gamma_dist(Ymes, Ypre, fname, language='English'):
 def plot_rmse_vs_time(Ymes, Ypre, Time, Date, name):
 
     fw, fh = 6, 6
-    fig = mpl.figure.Figure(figsize=(fw, fh), facecolor='white')
+    fig = MplFigure(figsize=(fw, fh), facecolor='white')
     canvas = FigureCanvas(fig)
 
     # ---- Create Axes

--- a/gwhat/meteo/weather_station_finder.py
+++ b/gwhat/meteo/weather_station_finder.py
@@ -142,7 +142,7 @@ class WeatherStationFinder(QObject):
             self.sig_progress_msg.emit(
                     "Loading the climate station database from file.")
             ts = time.time()
-            self._data = np.load(DATABASE_FILEPATH).item()
+            self._data = np.load(DATABASE_FILEPATH, allow_pickle=True).item()
             te = time.time()
             print("Station list loaded sucessfully in %0.2f sec." % (te-ts))
             self.sig_load_database_finished.emit(True)

--- a/gwhat/meteo/weather_viewer.py
+++ b/gwhat/meteo/weather_viewer.py
@@ -19,6 +19,9 @@ from datetime import datetime
 
 import numpy as np
 import matplotlib as mpl
+from matplotlib.patches import Rectangle
+from matplotlib.figure import Figure as MplFigure
+from matplotlib.transforms import ScaledTranslation
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 
 from PyQt5.QtCore import Qt, QSize
@@ -350,7 +353,7 @@ class FigWeatherNormals(FigureCanvasQTAgg):
         self.normals = None
 
         fw, fh = 8.5, 5.
-        fig = mpl.figure.Figure(figsize=(fw, fh), facecolor='white')
+        fig = MplFigure(figsize=(fw, fh), facecolor='white')
         super(FigWeatherNormals, self).__init__(fig)
 
         # Define the Margins :
@@ -379,7 +382,7 @@ class FigWeatherNormals(FigureCanvasQTAgg):
         # padding of 5 points and downward padding of 3 points.
 
         dx, dy = 5/72., -3/72.
-        padding = mpl.transforms.ScaledTranslation(dx, dy, fig.dpi_scale_trans)
+        padding = ScaledTranslation(dx, dy, fig.dpi_scale_trans)
         transform = ax3.transAxes + padding
 
         ax3.text(0., 1., 'Mean Annual Air Temperature',
@@ -531,8 +534,7 @@ class FigWeatherNormals(FigureCanvasQTAgg):
 
         # bbox transform :
 
-        padding = mpl.transforms.ScaledTranslation(5/72, -5/72,
-                                                   self.figure.dpi_scale_trans)
+        padding = ScaledTranslation(5/72, -5/72, self.figure.dpi_scale_trans)
         transform = ax.transAxes + padding
 
         # Define proxy artists :
@@ -540,10 +542,8 @@ class FigWeatherNormals(FigureCanvasQTAgg):
         colors = ColorsReader()
         colors.load_colors_db()
 
-        rec1 = mpl.patches.Rectangle((0, 0), 1, 1,
-                                     fc=colors.rgb['Snow'], ec='none')
-        rec2 = mpl.patches.Rectangle((0, 0), 1, 1,
-                                     fc=colors.rgb['Rain'], ec='none')
+        rec1 = Rectangle((0, 0), 1, 1, fc=colors.rgb['Snow'], ec='none')
+        rec2 = Rectangle((0, 0), 1, 1, fc=colors.rgb['Rain'], ec='none')
 
         # Define the legend labels and markers :
 

--- a/gwhat/meteo/weather_viewer.py
+++ b/gwhat/meteo/weather_viewer.py
@@ -24,7 +24,7 @@ from matplotlib.figure import Figure as MplFigure
 from matplotlib.transforms import ScaledTranslation
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 
-from PyQt5.QtCore import Qt, QSize
+from PyQt5.QtCore import Qt
 from PyQt5.QtCore import pyqtSlot as QSlot
 from PyQt5.QtWidgets import (QMenu, QToolButton, QGridLayout, QWidget,
                              QFileDialog, QApplication, QTableWidget,
@@ -38,7 +38,6 @@ from gwhat.common import StyleDB
 from gwhat.utils import icons
 from gwhat.utils.icons import QToolButtonVRectSmall, QToolButtonNormal
 from gwhat.common.widgets import DialogWindow
-from gwhat.widgets.layout import VSep
 from gwhat.widgets.buttons import RangeSpinBoxes
 from gwhat.meteo.weather_reader import calcul_monthly_normals
 from gwhat.common.utils import save_content_to_file
@@ -54,6 +53,7 @@ class WeatherViewer(DialogWindow):
     GUI that allows to plot weather normals, save the graphs to file, see
     various stats about the dataset, etc...
     """
+
     def __init__(self, parent=None, workdir=None):
         super(WeatherViewer, self).__init__(parent, False, False)
 


### PR DESCRIPTION
Some changes were made to the matplotlib api that caused the following error:

```python
gwhat\brf_mod\tests\test_brf_mod.py:18: in <module>
    from gwhat.brf_mod.kgs_gui import (BRFManager, KGSBRFInstaller, QMessageBox,
gwhat\brf_mod\__init__.py:15: in <module>
    from gwhat.brf_mod.kgs_gui import BRFManager
gwhat\brf_mod\kgs_gui.py:48: in <module>
    from gwhat.brf_mod.kgs_plot import BRFFigure
gwhat\brf_mod\kgs_plot.py:34: in <module>
    class BRFFigure(mpl.figure.Figure):
E   AttributeError: module 'matplotlib' has no attribute 'figure'
```
So the solution is to import `Figure` explicitly like `from matplotlib.figure import Figure`
