### PR TITLE
PR: Add xls and xlsx option to import weather data dialog

### DIFF
--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -669,7 +669,7 @@ class NewDatasetDialog(QDialog):
         if self._datatype == 'water level':
             exts = '(*.csv;*.xls;*.xlsx)'
         elif self._datatype == 'daily weather':
-            exts = '(*.csv;*.out)'
+            exts = '(*.csv;*.out;*.xls;*.xlsx)'
         filename, _ = QFileDialog.getOpenFileName(
             self, 'Select a %s data file' % self._datatype,
             self.workdir, exts)


### PR DESCRIPTION
Though the option was added in the code in version 0.4.0, it was still not possible to select input weather data files in the `xls` and `xlsx` format.

![image](https://user-images.githubusercontent.com/10170372/67162072-b0b1d380-f32e-11e9-95bf-915229be716e.png)
