### PR TITLE
PR: Prevent key error when saving old recharge results to file

### DIFF
--- a/gwhat/gwrecharge/glue.py
+++ b/gwhat/gwrecharge/glue.py
@@ -155,7 +155,15 @@ class GLUEDataFrameBase(Mapping):
         keys = ['Station ID', 'Location', 'Latitude',
                 'Longitude', 'Elevation']
         for key in keys:
-            header.append([key, self['wxinfo'][key]])
+            try:
+                header.append([key, self['wxinfo'][key]])
+            except KeyError:
+                if key == 'Station ID':
+                    try:
+                        header.append(
+                            [key, self['wxinfo']['Climate Identifier']])
+                    except KeyError:
+                        continue
 
         # Add the GWHAT version and date of creation.
         header.extend([

--- a/gwhat/gwrecharge/glue.py
+++ b/gwhat/gwrecharge/glue.py
@@ -156,6 +156,8 @@ class GLUEDataFrameBase(Mapping):
                 'Longitude', 'Elevation']
         for key in keys:
             try:
+                # We need to do this for backward compatibility with
+                # older version of GWHAT. See jnsebgosselin/gwhat#305.
                 header.append([key, self['wxinfo'][key]])
             except KeyError:
                 if key == 'Station ID':


### PR DESCRIPTION
Since `Climatic Identifier` key was changed to `Station ID`, we need to add some try/except code to prevent a `KeyError` when saving old recharge simulation results to file.