### PR TITLE
PR: Pin matplotlib and pyqt versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ xlwt
 cython>=0.25.2
 numpy>1.14
 scipy
-matplotlib>=2.0.2
+matplotlib == 3.1.*
 requests
 h5py>=2.8
 qtawesome

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appconfigs
-pyqt5==5.9.*
+pyqt5 == 5.12.*
 xlsxwriter
 xlrd
 xlwt


### PR DESCRIPTION
- We pin matplotlib version to 3.1.* because the private variable `NavigationToolbar2QT._active` have been removed in more recent version.
- We upgrade the version of pyqt since the 5.9 is not supported anymore and 5.12 is now very stable.