### PR TITLE
PR: Expand tests for the project selector

### DIFF
--- a/gwhat/projet/tests/test_project.py
+++ b/gwhat/projet/tests/test_project.py
@@ -113,6 +113,7 @@ def test_create_new_projet(projmanager, mocker, projectpath):
     assert projmanager.project_selector.text() == NAME + '.gwt'
     assert projmanager.project_selector.recent_projects() == [
         projectpath]
+    assert len(projmanager.project_selector.menu.actions()) == 4
 
     # Close the project.
     projmanager.close_projet()
@@ -139,6 +140,7 @@ def test_load_projet(projmanager, mocker, projectfile):
     assert projmanager.project_selector.text() == NAME + '.gwt'
     assert projmanager.project_selector.recent_projects() == [
         projectfile]
+    assert len(projmanager.project_selector.menu.actions()) == 4
 
     projmanager.close_projet()
 
@@ -157,6 +159,7 @@ def test_load_non_existing_project(projmanager, mocker, projectpath):
     assert projmanager.projet is None
     assert projmanager.project_selector.text() == ''
     assert projmanager.project_selector.recent_projects() == []
+    assert len(projmanager.project_selector.menu.actions()) == 3
 
 
 def test_load_invalid_project(projmanager, mocker, projectpath):
@@ -178,6 +181,7 @@ def test_load_invalid_project(projmanager, mocker, projectpath):
     assert projmanager.projet is None
     assert projmanager.project_selector.text() == ''
     assert projmanager.project_selector.recent_projects() == []
+    assert len(projmanager.project_selector.menu.actions()) == 3
 
 
 def test_load_corrupt_project_continue(projmanager, mocker, projectfile):
@@ -206,6 +210,7 @@ def test_load_corrupt_project_continue(projmanager, mocker, projectfile):
     assert projmanager.project_selector.text() == NAME + '.gwt'
     assert projmanager.project_selector.recent_projects() == [
         projectfile]
+    assert len(projmanager.project_selector.menu.actions()) == 4
 
     # Backup file are not generated when the project is corrupt.
     assert not osp.exists(projectfile + '.bak')
@@ -232,6 +237,7 @@ def test_load_corrupt_project_cancel(projmanager, mocker, projectfile):
     assert projmanager.projet is None
     assert projmanager.project_selector.text() == ''
     assert projmanager.project_selector.recent_projects() == []
+    assert len(projmanager.project_selector.menu.actions()) == 3
 
     # Backup file are not generated when the project is corrupt.
     assert not osp.exists(projectfile + '.bak')
@@ -255,6 +261,7 @@ def test_restore_invalid_project(projmanager, mocker, projectfile, bakfile):
     assert projmanager.projet is None
     assert projmanager.project_selector.text() == ''
     assert projmanager.project_selector.recent_projects() == []
+    assert len(projmanager.project_selector.menu.actions()) == 3
 
     # Try loading the corrupt project and accept to restore from backup.
     mock_qmsgbox.return_value = QMessageBox.Yes
@@ -270,6 +277,7 @@ def test_restore_invalid_project(projmanager, mocker, projectfile, bakfile):
     assert projmanager.project_selector.text() == NAME + '.gwt'
     assert projmanager.project_selector.recent_projects() == [
         projectfile]
+    assert len(projmanager.project_selector.menu.actions()) == 4
 
 
 def test_restore_invalid_project_from_invalid_backup(projmanager, mocker,
@@ -295,6 +303,7 @@ def test_restore_invalid_project_from_invalid_backup(projmanager, mocker,
     assert projmanager.projet is None
     assert projmanager.project_selector.text() == ''
     assert projmanager.project_selector.recent_projects() == []
+    assert len(projmanager.project_selector.menu.actions()) == 3
 
 
 def test_restore_corrupt_project(projmanager, mocker, projectfile, bakfile):
@@ -316,6 +325,7 @@ def test_restore_corrupt_project(projmanager, mocker, projectfile, bakfile):
     assert projmanager.projet is None
     assert projmanager.project_selector.text() == ''
     assert projmanager.project_selector.recent_projects() == []
+    assert len(projmanager.project_selector.menu.actions()) == 3
 
     # Try loading the corrupt project and click Ignore.
     mock_checkproj.reset_mock()
@@ -330,6 +340,7 @@ def test_restore_corrupt_project(projmanager, mocker, projectfile, bakfile):
     assert projmanager.project_selector.text() == NAME + '.gwt'
     assert projmanager.project_selector.recent_projects() == [
         projectfile]
+    assert len(projmanager.project_selector.menu.actions()) == 4
 
     # Try loading the corrupt project and click Yes.
     mock_checkproj.reset_mock()
@@ -344,6 +355,7 @@ def test_restore_corrupt_project(projmanager, mocker, projectfile, bakfile):
     assert projmanager.project_selector.text() == NAME + '.gwt'
     assert projmanager.project_selector.recent_projects() == [
         projectfile]
+    assert len(projmanager.project_selector.menu.actions()) == 4
 
 
 if __name__ == "__main__":

--- a/gwhat/projet/tests/test_project_selector.py
+++ b/gwhat/projet/tests/test_project_selector.py
@@ -46,6 +46,7 @@ def project_selector(qtbot, projectfiles):
 
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 2, 3]])
+    assert len(project_selector.menu.actions()) == 6
     assert project_selector._current_project is None
     assert project_selector.text() == ''
 
@@ -82,21 +83,25 @@ def test_add_recent_project(project_selector, projectfiles):
     project_selector.add_recent_project(None)
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 2, 3]])
+    assert len(project_selector.menu.actions()) == 6
 
     # Test adding a project whose file is NOT accessible.
     project_selector.add_recent_project(projectfiles[1])
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 2, 3]])
+    assert len(project_selector.menu.actions()) == 6
 
     # Test adding a project that is already in the list of recent projects.
     project_selector.add_recent_project(projectfiles[2])
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [2, 0, 3]])
+    assert len(project_selector.menu.actions()) == 6
 
     # Test adding a project that is not in the list of recent projects.
     project_selector.add_recent_project(projectfiles[4])
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [4, 2, 0]])
+    assert len(project_selector.menu.actions()) == 6
 
 
 def test_remove_recent_project(project_selector, projectfiles):
@@ -107,21 +112,25 @@ def test_remove_recent_project(project_selector, projectfiles):
     project_selector.remove_recent_project(None)
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 2, 3]])
+    assert len(project_selector.menu.actions()) == 6
 
     # Test removing a project whose file is NOT accessible.
     project_selector.remove_recent_project(projectfiles[1])
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 2, 3]])
+    assert len(project_selector.menu.actions()) == 6
 
     # Test removing a project that is NOT in the list of recent projects.
     project_selector.remove_recent_project(projectfiles[4])
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 2, 3]])
+    assert len(project_selector.menu.actions()) == 6
 
     # Test removing a project that is in the list of recent projects.
     project_selector.remove_recent_project(projectfiles[2])
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 3]])
+    assert len(project_selector.menu.actions()) == 5
 
 
 def test_delete_recent_project(project_selector, projectfiles, qtbot):
@@ -134,6 +143,7 @@ def test_delete_recent_project(project_selector, projectfiles, qtbot):
     assert len(project_selector.menu.actions()) == 3 + 3
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 2, 3]])
+    assert len(project_selector.menu.actions()) == 6
 
     # Try to remove a protected action.
     pos = project_selector.menu.actionGeometry(
@@ -143,6 +153,7 @@ def test_delete_recent_project(project_selector, projectfiles, qtbot):
     assert len(project_selector.menu.actions()) == 3 + 3
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 2, 3]])
+    assert len(project_selector.menu.actions()) == 6
 
     # Try to remove a recent project.
     pos = project_selector.menu.actionGeometry(
@@ -152,6 +163,7 @@ def test_delete_recent_project(project_selector, projectfiles, qtbot):
     assert len(project_selector.menu.actions()) == 3 + 2
     assert project_selector.recent_projects() == (
         [projectfiles[i] for i in [0, 3]])
+    assert len(project_selector.menu.actions()) == 5
 
     project_selector.menu.close()
 


### PR DESCRIPTION
This is a follow up to PR #307 to expand tests to cover the project selector.