### PR TITLE
PR: Remove scipy dependencies

### DIFF
--- a/releases/gwhat.spec
+++ b/releases/gwhat.spec
@@ -11,7 +11,6 @@ added_files = [('../gwhat/ressources/splash.png', 'ressources'),
                ]
 
 HIDDENIMPORTS = ['h5py.defs', 'h5py.utils', 'h5py.h5ac', 'h5py._proxy',
-                 'scipy.stats._continuous_distns', 'scipy._lib.messagestream',
                  'numpy.core._dtype_ctypes']
 
 a = Analysis(['../gwhat/mainwindow.py'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ xlrd
 xlwt
 cython>=0.25.2
 numpy>1.14
-scipy
 matplotlib == 3.1.*
 requests
 h5py>=2.8


### PR DESCRIPTION
This is not needed anymore since the removal of the tool to fill missing weather data in PR #293.