### PR TITLE
PR: Save BRF graphs language in user configs

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -551,6 +551,11 @@ class WLCalc(DialogWindow, SaveFileMixin):
         self.rechg_eval_widget.set_wxdset(wxdset)
         self.draw_weather()
 
+    def close(self):
+        """Close this groundwater level calc window."""
+        self.brf_eval_widget.close()
+        super().close()
+
     # ---- MRC handlers
 
     def btn_show_mrc_isclicked(self):

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -137,7 +137,7 @@ class BRFManager(myqt.QFrameLayout):
     def __initGUI__(self):
         self.setContentsMargins(10, 10, 10, 10)
 
-        # ---- Detrend and Correct Options
+        # Detrend and Correct Options
         self.baro_spinbox = myqt.QDoubleSpinBox(100, 0, show_buttons=True)
         self.baro_spinbox.setRange(0, 9999)
         self.baro_spinbox.setKeyboardTracking(True)
@@ -166,7 +166,7 @@ class BRFManager(myqt.QFrameLayout):
         options_layout.setColumnStretch(1, 100)
         options_layout.setContentsMargins(0, 0, 0, 0)
 
-        # ---- BRF date range
+        # Setup BRF date range widgets.
         self.date_start_edit = QDateTimeEdit()
         self.date_start_edit.setCalendarPopup(True)
         self.date_start_edit.setDisplayFormat('dd/MM/yyyy hh:mm')
@@ -201,7 +201,7 @@ class BRFManager(myqt.QFrameLayout):
         seldata_layout.setRowStretch(1, 100)
         seldata_layout.setContentsMargins(0, 0, 0, 0)
 
-        # ---- Toolbar
+        # Setup the toolbar.
         btn_comp = QPushButton('Compute BRF')
         btn_comp.clicked.connect(self.calc_brf)
         btn_comp.setFocusPolicy(Qt.NoFocus)
@@ -209,7 +209,7 @@ class BRFManager(myqt.QFrameLayout):
         self.btn_show = QToolButtonSmall(icons.get_icon('search'))
         self.btn_show.clicked.connect(self.viewer.show)
 
-        # ---- Main Layout
+        # Setup the main Layout.
         self.addLayout(daterange_layout, 0, 0)
         self.addLayout(seldata_layout, 0, 1)
         self.setRowMinimumHeight(1, 15)
@@ -224,7 +224,7 @@ class BRFManager(myqt.QFrameLayout):
         if not KGSBRFInstaller().kgsbrf_is_installed():
             self.__install_kgs_brf_installer()
 
-    # ---- Properties
+    # ---- Public API
 
     @property
     def nlag_baro(self):
@@ -279,26 +279,6 @@ class BRFManager(myqt.QFrameLayout):
                 widget.blockSignals(False)
         self.wldset.save_brfperiod(period)
 
-    # ---- KGS BRF installer
-    def __install_kgs_brf_installer(self):
-        """
-        Installs a KGSBRFInstaller that overlays the whole brf tool
-        layout until the KGS_BRF program is installed correctly.
-        """
-        self.kgs_brf_installer = KGSBRFInstaller()
-        self.kgs_brf_installer.sig_kgs_brf_installed.connect(
-                self.__uninstall_kgs_brf_installer)
-        self.addWidget(self.kgs_brf_installer, 0, 0,
-                       self.rowCount(), self.columnCount())
-
-    def __uninstall_kgs_brf_installer(self):
-        """
-        Uninstall the KGSBRFInstaller after the KGS_BRF program has been
-        installed properly.
-        """
-        self.kgs_brf_installer.sig_kgs_brf_installed.disconnect()
-        self.kgs_brf_installer = None
-
     def set_wldset(self, wldset):
         """Set the namespace for the wldset in the widget."""
         self.wldset = wldset
@@ -325,6 +305,27 @@ class BRFManager(myqt.QFrameLayout):
             widget.setMaximumDateTime(qdatetime_from_xldate(daterange[1]))
             widget.blockSignals(False)
 
+    # ---- KGS BRF installer
+    def __install_kgs_brf_installer(self):
+        """
+        Installs a KGSBRFInstaller that overlays the whole brf tool
+        layout until the KGS_BRF program is installed correctly.
+        """
+        self.kgs_brf_installer = KGSBRFInstaller()
+        self.kgs_brf_installer.sig_kgs_brf_installed.connect(
+                self.__uninstall_kgs_brf_installer)
+        self.addWidget(self.kgs_brf_installer, 0, 0,
+                       self.rowCount(), self.columnCount())
+
+    def __uninstall_kgs_brf_installer(self):
+        """
+        Uninstall the KGSBRFInstaller after the KGS_BRF program has been
+        installed properly.
+        """
+        self.kgs_brf_installer.sig_kgs_brf_installed.disconnect()
+        self.kgs_brf_installer = None
+
+    # ---- Calculations
     def calc_brf(self):
         """Prepare the data, calcul the brf, and save and plot the results."""
 
@@ -438,8 +439,7 @@ class BRFViewer(QWidget):
 
         self.total_brf = QLabel('/ 0')
 
-        # ---- Language button
-
+        # Setup the language button.
         self.btn_language = LangToolButton()
         self.btn_language.setToolTip(
             "Set the language of the text shown in the graph.")

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -130,7 +130,11 @@ class BRFManager(myqt.QFrameLayout):
     def __init__(self, wldset=None, parent=None):
         super(BRFManager, self).__init__(parent)
 
+        # Setup the BRF results viewer.
         self.viewer = BRFViewer(wldset, parent)
+        self.viewer.btn_language.set_language(
+            CONF.get('brf', 'graphs_labels_language'))
+
         self.kgs_brf_installer = None
         self.__initGUI__()
 
@@ -225,6 +229,11 @@ class BRFManager(myqt.QFrameLayout):
             self.__install_kgs_brf_installer()
 
     # ---- Public API
+    def close(self):
+        """"Clos this brf manager"""
+        CONF.set('brf', 'graphs_labels_language',
+                 self.viewer.btn_language.language)
+        super().close()
 
     @property
     def nlag_baro(self):

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -33,13 +33,12 @@ import matplotlib as mpl
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 
 
-# ---- Imports: Local
-
+# ---- Local imports
 import gwhat.common.widgets as myqt
 from gwhat.widgets.layout import VSep, HSep
-from gwhat.widgets.buttons import (LangToolButton, OnOffToolButton,
-                                   ExportDataButton)
+from gwhat.widgets.buttons import LangToolButton, OnOffToolButton
 from gwhat.common import StyleDB
+from gwhat.config.main import CONF
 from gwhat.utils import icons
 from gwhat.utils.icons import QToolButtonNormal, QToolButtonSmall
 from gwhat.utils.dates import qdatetime_from_xldate

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -678,7 +678,7 @@ class BRFViewer(QWidget):
 
     def plot_brf(self):
         self.brf_canvas.figure.set_language(self.btn_language.language)
-        if self.wldset.brf_count() == 0:
+        if self.wldset is None or self.wldset.brf_count() == 0:
             self.brf_canvas.figure.empty_BRF()
         else:
             name = self.wldset.get_brfname_at(self.current_brf.value()-1)

--- a/gwhat/config/main.py
+++ b/gwhat/config/main.py
@@ -31,6 +31,9 @@ DEFAULTS = [
          'last_project_filepath': '../Projects/Example/Example.gwt'
          }
      ),
+    ('brf',
+        {'graphs_labels_language': 'english'}
+     ),
 ]
 
 

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -202,6 +202,7 @@ class MainWindow(QMainWindow):
         """Qt method override to close the project before close the app."""
         print('Closing projet')
         self.pmanager.close()
+        self.tab_hydrocalc.close()
         print('Closing GWHAT')
         event.accept()
 


### PR DESCRIPTION
The idea is to save the language that is used for the labels of the BRF graphs when closing GWHAT and to remember the language used when GWHAT is restarted.

![image](https://user-images.githubusercontent.com/10170372/93262721-b1d3c680-f772-11ea-8d00-1e851271b4f8.png)
