### PR TITLE
PR: Set/Get from the user configs the visibility status of the BRF results viewer options panel

### DIFF
--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -538,6 +538,7 @@ class BRFViewer(QDialog):
         main_layout.addWidget(self.fig_frame, 0, 2)
         main_layout.addWidget(self.graph_opt_panel, 0, 3)
         main_layout.setColumnStretch(1, 100)
+        main_layout.setSizeConstraint(main_layout.SetFixedSize)
 
     @property
     def savedir(self):
@@ -559,17 +560,11 @@ class BRFViewer(QDialog):
             self.graph_opt_panel.setVisible(False)
             self.btn_setp.setAutoRaise(True)
             self.btn_setp.setToolTip('Show graph layout parameters...')
-
-            w = self.size().width() - self.graph_opt_panel.size().width()
-            self.setFixedWidth(w)
         else:
             # Show the panel.
             self.graph_opt_panel.setVisible(True)
             self.btn_setp.setAutoRaise(False)
             self.btn_setp.setToolTip('Hide graph layout parameters...')
-
-            w = self.size().width() + self.graph_opt_panel.size().width()
-            self.setFixedWidth(w)
 
     def navigate_brf(self):
         if self.sender() == self.btn_prev:

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -23,7 +23,7 @@ from PyQt5.QtWidgets import (QLabel, QDateTimeEdit, QCheckBox, QPushButton,
                              QApplication, QSpinBox, QAbstractSpinBox,
                              QGridLayout, QDoubleSpinBox, QFrame, QWidget,
                              QDesktopWidget, QMessageBox, QFileDialog,
-                             QComboBox, QLayout)
+                             QComboBox, QLayout, QDialog)
 
 from xlrd.xldate import xldate_from_datetime_tuple, xldate_as_datetime
 import numpy as np
@@ -419,7 +419,7 @@ class BRFManager(myqt.QFrameLayout):
             return
 
 
-class BRFViewer(QWidget):
+class BRFViewer(QDialog):
     """
     Window that is used to show all the results produced with for the
     currently selected water level dataset.
@@ -715,18 +715,6 @@ class BRFViewer(QWidget):
 
     def show(self):
         super(BRFViewer, self).show()
-        qr = self.frameGeometry()
-        if self.parentWidget():
-            parent = self.parentWidget()
-
-            wp = parent.frameGeometry().width()
-            hp = parent.frameGeometry().height()
-            cp = parent.mapToGlobal(QPoint(wp/2, hp/2))
-        else:
-            cp = QDesktopWidget().availableGeometry().center()
-
-        qr.moveCenter(cp)
-        self.move(qr.topLeft())
         self.fig_frame.setFixedSize(self.fig_frame.size())
         self.setFixedSize(self.size())
 

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -132,6 +132,8 @@ class BRFManager(myqt.QFrameLayout):
         self.viewer = BRFViewer(wldset, parent)
         self.viewer.btn_language.set_language(
             CONF.get('brf', 'graphs_labels_language'))
+        if CONF.get('brf', 'graph_opt_panel_is_visible', False):
+            self.viewer.toggle_graphpannel()
 
         self.kgs_brf_installer = None
         self.__initGUI__()
@@ -237,6 +239,8 @@ class BRFManager(myqt.QFrameLayout):
         """"Clos this brf manager"""
         CONF.set('brf', 'graphs_labels_language',
                  self.viewer.btn_language.language)
+        CONF.set('brf', 'graph_opt_panel_is_visible',
+                 self.viewer._graph_opt_panel_is_visible)
         CONF.set('brf', 'compute_with_earthtides',
                  self.earthtides_cbox.isChecked())
         CONF.set('brf', 'nbr_of_earthtides_lags',
@@ -532,6 +536,7 @@ class BRFViewer(QDialog):
         # Setup the graph options panel.
         self.graph_opt_panel = BRFOptionsPanel()
         self.graph_opt_panel.sig_graphconf_changed.connect(self.plot_brf)
+        self._graph_opt_panel_is_visible = False
 
         # Setup the main layout.
         main_layout = QGridLayout(self)
@@ -555,16 +560,16 @@ class BRFViewer(QDialog):
 
     # ---- Toolbar Handlers
     def toggle_graphpannel(self):
-        if self.graph_opt_panel.isVisible() is True:
-            # Hide the panel.
-            self.graph_opt_panel.setVisible(False)
-            self.btn_setp.setAutoRaise(True)
-            self.btn_setp.setToolTip('Show graph layout parameters...')
-        else:
-            # Show the panel.
-            self.graph_opt_panel.setVisible(True)
-            self.btn_setp.setAutoRaise(False)
-            self.btn_setp.setToolTip('Hide graph layout parameters...')
+        """
+        Hide or show the BRF graph option panel.
+        """
+        self._graph_opt_panel_is_visible = not self._graph_opt_panel_is_visible
+        self.graph_opt_panel.setVisible(self._graph_opt_panel_is_visible)
+        self.btn_setp.setAutoRaise(not self._graph_opt_panel_is_visible)
+        self.btn_setp.setToolTip(
+            'Show graph layout parameters...' if
+            self._graph_opt_panel_is_visible is False else
+            'Hide graph layout parameters...')
 
     def navigate_brf(self):
         if self.sender() == self.btn_prev:

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -516,8 +516,7 @@ class BRFViewer(QDialog):
         self.tbar.setColumnStretch(row, 100)
         self.tbar.setContentsMargins(10, 0, 10, 10)  # (l, t, r, b)
 
-        # ---- Graph Canvas
-
+        # Setup the graph canvas.
         self.fig_frame = QFrame()
         self.fig_frame.setFrameStyle(StyleDB().frame)
         self.fig_frame.setObjectName("figframe")
@@ -530,19 +529,15 @@ class BRFViewer(QDialog):
         fflay.addWidget(self.tbar, 1, 0)
         fflay.addWidget(self.brf_canvas, 0, 0)
 
-        # ---- Graph Options Panel
-
+        # Setup the graph options panel.
         self.graph_opt_panel = BRFOptionsPanel()
         self.graph_opt_panel.sig_graphconf_changed.connect(self.plot_brf)
 
-        # ---- Main Layout
-
-        ml = QGridLayout(self)
-
-        ml.addWidget(self.fig_frame, 0, 2)
-        ml.addWidget(self.graph_opt_panel, 0, 3)
-
-        ml.setColumnStretch(1, 100)
+        # Setup the main layout.
+        main_layout = QGridLayout(self)
+        main_layout.addWidget(self.fig_frame, 0, 2)
+        main_layout.addWidget(self.graph_opt_panel, 0, 3)
+        main_layout.setColumnStretch(1, 100)
 
     @property
     def savedir(self):

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -16,14 +16,13 @@ import io
 
 
 # ---- Third party imports
-from PyQt5.QtCore import Qt, QPoint
+from PyQt5.QtCore import Qt
 from PyQt5.QtCore import pyqtSignal as QSignal
 from PyQt5.QtGui import QImage
-from PyQt5.QtWidgets import (QLabel, QDateTimeEdit, QCheckBox, QPushButton,
-                             QApplication, QSpinBox, QAbstractSpinBox,
-                             QGridLayout, QDoubleSpinBox, QFrame, QWidget,
-                             QDesktopWidget, QMessageBox, QFileDialog,
-                             QComboBox, QLayout, QDialog)
+from PyQt5.QtWidgets import (
+    QLabel, QDateTimeEdit, QCheckBox, QPushButton, QApplication, QSpinBox,
+    QAbstractSpinBox, QGridLayout, QDoubleSpinBox, QFrame, QWidget,
+    QMessageBox, QFileDialog, QComboBox, QLayout, QDialog)
 
 from xlrd.xldate import xldate_from_datetime_tuple, xldate_as_datetime
 import numpy as np

--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -241,6 +241,8 @@ class BRFManager(myqt.QFrameLayout):
                  self.viewer.btn_language.language)
         CONF.set('brf', 'graph_opt_panel_is_visible',
                  self.viewer._graph_opt_panel_is_visible)
+        self.viewer.close()
+
         CONF.set('brf', 'compute_with_earthtides',
                  self.earthtides_cbox.isChecked())
         CONF.set('brf', 'nbr_of_earthtides_lags',


### PR DESCRIPTION
The visibility status of the options panel is now saved when exiting GWHAT and remembered when restarting the app.

This PR also make some change to the code to make it clearer and easier to maintain.

![image](https://user-images.githubusercontent.com/10170372/93910474-222c9b80-fccf-11ea-80d6-8dd43141d328.png)
