### PR TITLE
PR: Improve the setup of the right panel width

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -505,7 +505,6 @@ class WLCalc(DialogWindow, SaveFileMixin):
 
         main_layout.setHorizontalSpacing(15)
         main_layout.setColumnStretch(0, 100)
-        main_layout.setColumnMinimumWidth(2, 250)
 
     @property
     def water_lvl(self):

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -181,7 +181,6 @@ class HydroprintGUI(myqt.DialogWindow):
         main_layout.addWidget(self.right_panel, 0, 2)
         main_layout.setSpacing(15)
         main_layout.setColumnStretch(0, 500)
-        main_layout.setColumnMinimumWidth(2, 250)
 
         # ---- EVENTS
 

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -178,6 +178,14 @@ class MainWindow(QMainWindow):
         Move the data manager from tab 'Plot Hydrograph' to tab
         'Analyze Hydrograph' and vice-versa.
         """
+        max_width = self.dmanager.sizeHint().width()
+        for i in range(self.tab_widget.count()):
+            max_width = max(
+                max_width,
+                self.tab_widget.widget(i).right_panel.sizeHint().width())
+        for i in range(self.tab_widget.count()):
+            self.tab_widget.widget(i).layout().setColumnMinimumWidth(
+                2, max_width)
         self.tab_widget.currentWidget().right_panel.layout().addWidget(
             self.dmanager, 0, 0)
 

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -86,7 +86,6 @@ class MainWindow(QMainWindow):
 
         # Setup the data manager.
         self.dmanager = DataManager(parent=self, pm=self.pmanager)
-        self.dmanager.setMaximumWidth(250)
         self.dmanager.sig_new_console_msg.connect(self.write2console)
 
         # Generate the GUI.

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -273,8 +273,6 @@ def except_hook(cls, exception, traceback):
     sys.__excepthook__(cls, exception, traceback)
 
 
-# %% if __name__ == '__main__'
-
 if __name__ == '__main__':
     sys.excepthook = except_hook
     main = MainWindow()


### PR DESCRIPTION
This PR now remove any hard coding value for the right panel width and make sure that the panel width is the same for the `plot` and `analyze` tab.

![image](https://user-images.githubusercontent.com/10170372/94844276-02daf000-03ec-11eb-9043-43de2fe3c57c.png)
