### PR TITLE
PR: Improve xticks and xtick labels plotting in hydrographs

### DIFF
--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -1043,7 +1043,7 @@ class Hydrograph(Figure):
             offset = ScaledTranslation(0, dy/72, self.dpi_scale_trans)
             self.figTitle.set_text(labelDB.title % self.wldset['Well'])
             self.figTitle.set_transform(self.ax0.transAxes + offset)
-
+        self.ax1.set_xticks(xticks_info[3], minor=True)
         # Set whether the title is visible or not.
         self.text1.set_visible(self.meteo_on and self.isGraphTitle)
         self.figTitle.set_visible(self.isGraphTitle)

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -1043,11 +1043,11 @@ class Hydrograph(Figure):
             offset = ScaledTranslation(0, dy/72, self.dpi_scale_trans)
             self.figTitle.set_text(labelDB.title % self.wldset['Well'])
             self.figTitle.set_transform(self.ax0.transAxes + offset)
-        self.ax1.set_xticks(xticks_info[3], minor=True)
+
         # Set whether the title is visible or not.
         self.text1.set_visible(self.meteo_on and self.isGraphTitle)
         self.figTitle.set_visible(self.isGraphTitle)
-
+        self.ax1.set_xticks(xticks_info[3], minor=True)
     def setup_waterlvl_scale(self):
         """Update the y scale of the water levels."""
         NZGrid = self.NZGrid if self.meteo_on else self.NZGrid - 2

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -1179,60 +1179,45 @@ class Hydrograph(Figure):
 
         # Transform to data coord :
 
-        n = self.date_labels_pattern
         month_names = LabelDatabase(self.language).month_names
 
         xticks_labels_offset = sdx
 
         xticks_labels = []
-        xticks_position = [self.TIMEmin]
+        xticks_position = []
         xticks_labels_position = []
+        xticks_minor_position = []
 
-        if self.datemode.lower() == 'month':
+        i = 0
+        next_xtick_pos = self.TIMEmin
+        while True:
+            datetuple = xldate_as_tuple(next_xtick_pos, 0)
+            year = datetuple[0]
+            month = datetuple[1]
+            month_range = monthrange(year, month)[1]
 
-            i = 0
-            while xticks_position[i] < self.TIMEmax:
-
-                year = xldate_as_tuple(xticks_position[i], 0)[0]
-                month = xldate_as_tuple(xticks_position[i], 0)[1]
-
-                month_range = monthrange(year, month)[1]
-
-                xticks_position.append(xticks_position[i] + month_range)
-
-                if i % n == 0:
-
-                    xticks_labels_position.append(xticks_position[i] +
-                                                  0.5 * month_range +
-                                                  xticks_labels_offset)
-
-                    xticks_labels.append("%s '%s" % (month_names[month - 1],
-                                                     str(year)[-2:]))
-
-                i += 1
-
-        elif self.datemode.lower() == 'year':
-
-            i = 0
-            year = xldate_as_tuple(xticks_position[i], 0)[0]
-            while xticks_position[i] < self.TIMEmax:
-
-                xticks_position.append(
-                                     xldate_from_date_tuple((year+1, 1, 1), 0))
-                year_range = xticks_position[i+1] - xticks_position[i]
-
-                if i % n == 0:
-
-                    xticks_labels_position.append(xticks_position[i] +
-                                                  0.5 * year_range +
-                                                  xticks_labels_offset)
-
+            xticks_minor_position.append(next_xtick_pos)
+            if i % self.date_labels_pattern == 0:
+                xticks_position.append(next_xtick_pos)
+                xticks_labels_position.append(
+                    next_xtick_pos + xticks_labels_offset)
+                if self.datemode.lower() == 'month':
+                    xticks_labels.append("{} '{}".format(
+                        month_names[month - 1], str(year)[-2:]))
+                elif self.datemode.lower() == 'year':
                     xticks_labels.append("%d" % year)
 
-                year += 1
-                i += 1
+            if self.datemode.lower() == 'month':
+                next_xtick_pos = next_xtick_pos + month_range
+            elif self.datemode.lower() == 'year':
+                next_xtick_pos = xldate_from_date_tuple((year + 1, 1, 1), 0)
 
-        return xticks_position, xticks_labels_position, xticks_labels
+            if next_xtick_pos > self.TIMEmax:
+                break
+            i += 1
+
+        return (xticks_position, xticks_labels_position, xticks_labels,
+                xticks_minor_position)
 
 
 def filt_data(time, waterlvl, N):

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -1014,6 +1014,7 @@ class Hydrograph(Figure):
         """
         xticks_info = self.make_xticks_info()
         self.ax1.set_xticks(xticks_info[0])
+        self.ax1.set_xticks(xticks_info[3], minor=True)
 
         for i in range(len(self.xlabels)):
             self.xlabels[i].remove()
@@ -1047,7 +1048,7 @@ class Hydrograph(Figure):
         # Set whether the title is visible or not.
         self.text1.set_visible(self.meteo_on and self.isGraphTitle)
         self.figTitle.set_visible(self.isGraphTitle)
-        self.ax1.set_xticks(xticks_info[3], minor=True)
+
     def setup_waterlvl_scale(self):
         """Update the y scale of the water levels."""
         NZGrid = self.NZGrid if self.meteo_on else self.NZGrid - 2

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -1142,8 +1142,6 @@ class Hydrograph(Figure):
 
     def make_xticks_info(self):
 
-        # ---------------------------------------- horizontal text alignment --
-
         # The strategy here is to:
         # 1. render some random text ;
         # 2. get the height of its bounding box ;
@@ -1170,8 +1168,7 @@ class Hydrograph(Figure):
 
         dx = bbox.height * np.sin(np.radians(45))
 
-        # Scale dx to axe dimension :
-
+        # Scale dx to axe dimension.
         bbox = self.ax1.get_window_extent(renderer)  # in pixels
         bbox = bbox.transformed(self.dpi_scale_trans.inverted())  # in inches
 

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -1017,7 +1017,7 @@ class Hydrograph(Figure):
         for i in range(len(self.xlabels)):
             self.xlabels[i].remove()
 
-        padding = ScaledTranslation(0, -5/72, self.dpi_scale_trans)
+        padding = ScaledTranslation(0, -6/72, self.dpi_scale_trans)
 
         self.xlabels = []
         for i in range(len(xticks_info[1])):

--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -1006,11 +1006,12 @@ class Hydrograph(Figure):
         self.ax1.axis([self.TIMEmin, self.TIMEmax, 0, self.NZGrid])
 
     def setup_xticklabels(self):
-        """Setup the xtick labels."""
+        """
+        Setup the xtick labels.
 
-        # Labels are placed manually because this is around 25% faster than
-        # using the minor ticks.
-
+        Note that labels are placed manually because this is around 25% faster
+        than using the minor ticks.
+        """
         xticks_info = self.make_xticks_info()
         self.ax1.set_xticks(xticks_info[0])
 


### PR DESCRIPTION
In my opinion, the way the xtick labels are currently aligned with the xticks is confusing, i.e. the top left corner of the labels is aligned with the middle position between the major tick marks.

Also, I think that using major xticks and enabling vertical grid for xticks that do not have a label make the graph too dense.

So this PR introduce the following changes to address the aforementioned issues:
- Aligned xtick label with the major xticks.
- Use minor ticks when there is no label.
- Don't use vertical grid for minor xticks.

![image](https://user-images.githubusercontent.com/10170372/98836370-9baf5300-240f-11eb-9eae-c753a20f10ac.png)


For comparison, this is what the xticks and xtick labels look like before this PR.

![image](https://user-images.githubusercontent.com/10170372/98836491-bc77a880-240f-11eb-9b50-836b990d059e.png)
