### PR TITLE
PR: Pin xlrd to the 1.* serie

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 appconfigs
 pyqt5 == 5.12.*
 xlsxwriter
-xlrd
+xlrd == 1.*
 xlwt
 cython>=0.25.2
 numpy == 1.16.*


### PR DESCRIPTION
Xlrd 2.x series does not support reading xlsx type files unlike the 1.x series. 

see https://github.com/python-excel/xlrd:
> This library will no longer read anything other than .xls files. For alternatives that read newer file formats, please see http://www.python-excel.org/.

We get an error when trying to read this type of file now, which is rather problematic. So we are going to pin `xlrd` to the 1.x series for the time being until we switch properly to another package to read xlsx files.