### PR TITLE
PR: Fix saving MRC data in project file

### DIFF
--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -253,7 +253,7 @@ class ProjetReader(object):
             mrc.attrs['exists'] = 0
             mrc.create_dataset('params', data=(0, 0), dtype='float64')
             mrc.create_dataset('peak_indx', data=np.array([]),
-                               dtype='int16', maxshape=(None,))
+                               dtype='int64', maxshape=(None,))
             mrc.create_dataset('recess', data=np.array([]),
                                dtype='float64', maxshape=(None,))
             mrc.create_dataset('time', data=np.array([]),

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -430,6 +430,17 @@ class WLDataFrameHDF5(WLDataFrameBase):
             # Added in version 0.3.1 (see PR #184)
             self.dset.create_group('glue')
             self.dset.file.flush()
+        if 'mrc' not in list(self.dset.keys()):
+            mrc = self.dset.create_group('mrc')
+            mrc.attrs['exists'] = 0
+            mrc.create_dataset('params', data=(0, 0), dtype='float64')
+            mrc.create_dataset('peak_indx', data=np.array([]),
+                               dtype='int64', maxshape=(None,))
+            mrc.create_dataset('recess', data=np.array([]),
+                               dtype='float64', maxshape=(None,))
+            mrc.create_dataset('time', data=np.array([]),
+                               dtype='float64', maxshape=(None,))
+            self.dset.file.flush()
 
     def __getitem__(self, key):
         if key in list(self.dset.attrs.keys()):
@@ -474,8 +485,7 @@ class WLDataFrameHDF5(WLDataFrameBase):
         grp = self.dset.require_group('manual')
         return grp['Time'][...], grp['WL'][...]
 
-    # ---- Master recession curve
-
+    # ---- Master Recession Curve
     def set_mrc(self, A, B, peak_indx, time, recess):
         """Save the mrc results to the hdf5 project file."""
         self.dset['mrc/params'][:] = (A, B)
@@ -495,16 +505,6 @@ class WLDataFrameHDF5(WLDataFrameBase):
 
     def mrc_exists(self):
         """Return whether a mrc results is saved in the hdf5 project file."""
-        if 'mrc' not in list(self.dset.keys()):
-            mrc = self.dset.create_group('mrc')
-            mrc.attrs['exists'] = 0
-            mrc.create_dataset('params', data=(0, 0), dtype='float64')
-            mrc.create_dataset('peak_indx', data=np.array([]),
-                               dtype='int16', maxshape=(None,))
-            mrc.create_dataset('recess', data=np.array([]),
-                               dtype='float64', maxshape=(None,))
-            mrc.create_dataset('time', data=np.array([]),
-                               dtype='float64', maxshape=(None,))
         return bool(self.dset['mrc'].attrs['exists'])
 
     def save_mrc_tofile(self, filename):

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -289,8 +289,8 @@ class WLDataFrameBase(Mapping):
         """Loads the dataset and save it in a store."""
         raise NotImplementedError
 
-    def __len__(self, key):
-        return len(self._datetimes)
+    def __len__(self):
+        return len(self._dataf)
 
     def __setitem__(self, key, value):
         return NotImplementedError


### PR DESCRIPTION
Fixes #358

The peak indexes corresponding to the recession periods were saved as int16, which is limited to a max value of 32767. This was causing problems when saving MRC data for large datasets with more than 32767 data.

This PR change the dtype of `peak_indx` to int64 instead of int16 and also implement some logic to convert `peak_indx` saved in old GWHAT project files to the new format.