### PR TITLE
PR: Package Gwhat with pyinstaller 4.2 from 3.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ test_script:
 
 after_test:
   # Install requirements for packaging GWHAT.
-  - python -m pip install pyinstaller==3.6 pywin32 tornado
+  - python -m pip install pyinstaller==4.2 pywin32 tornado
 
   # Package GWHAT with PyInstaller.
   - cmd: set PYTHONPATH=C:\projects\gwhat;%PYTHONPATH%


### PR DESCRIPTION
Now that two minor bug releases were published in the 4.x series of pyinstaller, I think it is worth to switch to it now.

This new version of pyinstaller should solve some problems with hooks and also solve a problem with matplotlib packaging.