### PR TITLE
PR: Prevent project corruption when setting last opened wldset and wxdset

### DIFF
--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -212,7 +212,7 @@ class ProjetReader(object):
         """
         print("Getting wldset {}...".format(name), end=' ')
         if name in self.wldsets:
-            self.db['wldsets'].attrs['last_opened'] = name
+            self.set_last_opened_wldset(name)
             print('done')
             return WLDataFrameHDF5(self.db['wldsets/%s' % name])
         else:
@@ -338,7 +338,7 @@ class ProjetReader(object):
         print("Getting wxdset {}...".format(name), end=' ')
         if name in self.wxdsets:
             print('done')
-            self.db['wxdsets'].attrs['last_opened'] = name
+            self.set_last_opened_wxdset(name)
             return WXDataFrameHDF5(self.db['wxdsets/%s' % name])
         else:
             print('failed')

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -199,6 +199,13 @@ class ProjetReader(object):
         name = self.db['wldsets'].attrs['last_opened']
         return None if name == 'None' else name
 
+    def set_last_opened_wldset(self, name):
+        """
+        Set the name of the last opened water level dataset.
+        """
+        self.db['wldsets'].attrs['last_opened'] = name
+        self.db.flush()
+
     def get_wldset(self, name):
         """
         Return the water level dataset corresponding to the provided name.
@@ -316,6 +323,13 @@ class ProjetReader(object):
         """
         name = self.db['wxdsets'].attrs['last_opened']
         return None if name == 'None' else name
+
+    def set_last_opened_wxdset(self, name):
+        """
+        Set the name of the last opened weather dataset.
+        """
+        self.db['wxdsets'].attrs['last_opened'] = name
+        self.db.flush()
 
     def get_wxdset(self, name):
         """

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -194,8 +194,7 @@ class ProjetReader(object):
 
     def get_last_opened_wldset(self):
         """
-        Return the name of the last opened water level dataset in the project
-        if any.
+        Return the name of the last opened water level dataset if any.
         """
         name = self.db['wldsets'].attrs['last_opened']
         return None if name == 'None' else name
@@ -313,8 +312,7 @@ class ProjetReader(object):
 
     def get_last_opened_wxdset(self):
         """
-        Return the name of the last opened weather dataset in the project
-        if any.
+        Return the name of the last opened weather dataset if any.
         """
         name = self.db['wxdsets'].attrs['last_opened']
         return None if name == 'None' else name


### PR DESCRIPTION
Sometimes, when GWHAT crash, the project is partially corrupted due to how we are setting the last opened wldset and wxdset.

This PR make some changes that should prevent that in the future.