### PR TITLE
PR: Fix an issue when evaluating recharge if the observed water levels start with a nan value

### DIFF
--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -415,7 +415,10 @@ class RechgEvalWorker(QObject):
         # I should check this out.
 
         A, B = self.A, self.B
-        wlobs = self.wlobs*1000
+        wlobs = self.wlobs.copy() * 1000
+        if np.isnan(wlobs[0]) or np.isnan(wlobs[-1]):
+            raise ValueError('The observed water level time series either '
+                             'starts or ends with a nann value.')
         if nscheme == 'backward':
             wlpre = np.zeros(len(RECHG)+1) * np.nan
             wlpre[0] = wlobs[-1]

--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -135,7 +135,16 @@ class RechgEvalWorker(QObject):
             if len(indx) > 0:
                 hd[i] = h[indx[-1]]
 
-        return td, hd
+        # We need to remove nan values at the start and the end of the series
+        # to avoid problems when computing synthetic hydrographs.
+        for istart in range(len(hd)):
+            if not np.isnan(hd[istart]):
+                break
+        for iend in reversed(range(len(hd))):
+            if not np.isnan(hd[iend]):
+                break
+
+        return td[istart:iend], hd[istart:iend]
 
     def produce_params_combinations(self):
         """


### PR DESCRIPTION
This can happen when water level data were deleted in gwhat at the start or the end of the series.

This results in an synthetic hydrograph that starts with a nan value. The nan value is then propagated forward in the whole series.