### PR TITLE
PR: Add copy clipboard to gwrecharge plots

### DIFF
--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -776,7 +776,7 @@ class FigCanvasBase(FigureCanvasQTAgg):
     def copy_to_clipboard(self):
         """Put a copy of the figure on the clipboard."""
         buf = io.BytesIO()
-        self.figure.savefig(buf)
+        self.figure.savefig(buf, dpi=300)
         QApplication.clipboard().setImage(QImage.fromData(buf.getvalue()))
         buf.close()
 

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -612,6 +612,13 @@ class FigureManager(QWidget):
             tip='Save current graph as...',
             triggered=self._select_savefig_path)
 
+        self.btn_copy_to_clipboard = create_toolbutton(
+            self, icon='copy_clipboard',
+            text="Copy",
+            tip="Put a copy of the figure on the Clipboard.",
+            triggered=self.figcanvas.copy_to_clipboard,
+            shortcut='Ctrl+C')
+
         self.btn_language = LangToolButton()
         self.btn_language.setToolTip(
             "Set the language of the text shown in the graph.")
@@ -627,7 +634,8 @@ class FigureManager(QWidget):
         toolbar.setMovable(False)
         toolbar.setIconSize(get_iconsize('normal'))
 
-        widgets = [self.btn_save, None, zoom_widget, None, self.btn_language]
+        widgets = [self.btn_save, self.btn_copy_to_clipboard, None,
+                   zoom_widget, None, self.btn_language]
         for widget in widgets:
             if widget is None:
                 toolbar.addSeparator()

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -8,6 +8,7 @@
 # -----------------------------------------------------------------------------
 
 # ---- Standard library imports
+import io
 import os
 import os.path as osp
 import datetime
@@ -22,6 +23,7 @@ from matplotlib.figure import Figure as MplFigure
 from PyQt5.QtCore import Qt
 from PyQt5.QtCore import pyqtSlot as QSlot
 from PyQt5.QtCore import pyqtSignal as QSignal
+from PyQt5.QtGui import QImage
 from PyQt5.QtWidgets import (
     QGridLayout, QAbstractSpinBox, QApplication, QDoubleSpinBox,
     QFileDialog, QGroupBox, QLabel, QMessageBox, QScrollArea, QScrollBar,
@@ -762,6 +764,13 @@ class FigCanvasBase(FigureCanvasQTAgg):
 
         self.figure.set_size_inches(self.setp['fwidth'], self.setp['fheight'])
         self.refresh_margins()
+
+    def copy_to_clipboard(self):
+        """Put a copy of the figure on the clipboard."""
+        buf = io.BytesIO()
+        self.figure.savefig(buf)
+        QApplication.clipboard().setImage(QImage.fromData(buf.getvalue()))
+        buf.close()
 
     def clear_ax(self, silent=True):
         """Clear the main axe."""

--- a/gwhat/gwrecharge/tests/test_gwrecharge_plot.py
+++ b/gwhat/gwrecharge/tests/test_gwrecharge_plot.py
@@ -12,6 +12,7 @@ import os.path as osp
 
 # ---- Third party imports
 import pytest
+from PyQt5.QtGui import QImage
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication
 
@@ -36,7 +37,7 @@ def project():
 @pytest.fixture()
 def figstackmanager(qtbot):
     figstackmanager = FigureStackManager()
-    # qtbot.addWidget(figstackmanager)
+    qtbot.addWidget(figstackmanager)
     figstackmanager.show()
     qtbot.waitForWindowShown(figstackmanager)
     return figstackmanager
@@ -61,5 +62,27 @@ def test_figstackmanager(figstackmanager, project):
         figstackmanager.stack.setCurrentIndex(index)
 
 
+def test_copy_to_clipboard(qtbot, figstackmanager, project):
+    """
+    Test that copying figures to the clipboard works as expected.
+    """
+    wldset = project.get_wldset('3040002_15min')
+    figstackmanager.set_gluedf(wldset.get_glue_at(-1))
+
+    for index in range(figstackmanager.stack.count()):
+        figstackmanager.stack.setCurrentIndex(index)
+        qtbot.wait(300)
+
+        QApplication.clipboard().clear()
+        assert QApplication.clipboard().text() == ''
+        assert QApplication.clipboard().image().isNull()
+
+        qtbot.mouseClick(
+            figstackmanager.figmanagers[index].btn_copy_to_clipboard,
+            Qt.LeftButton)
+
+        assert not QApplication.clipboard().image().isNull()
+
+
 if __name__ == "__main__":
-    pytest.main(['-x', __file__, '-v', '-rw', '-s'])
+    pytest.main(['-x', __file__, '-v', '-rw'])


### PR DESCRIPTION
That way we can quickly copy a figure to a document without having to do a printscreen or to save the figure on the disk.

![image](https://user-images.githubusercontent.com/10170372/113165820-3918f100-9210-11eb-822e-13459ae0bbc3.png)
