### PR TITLE
PR: don't add missing meteo data marker to legend if no missing data

### DIFF
--- a/gwhat/hydrograph4.py
+++ b/gwhat/hydrograph4.py
@@ -539,8 +539,9 @@ class Hydrograph(Figure):
                 lg_labels.append(labelDB[2])
 
                 # Missing Data Markers
-                lg_handles.append(self.lmiss_ax4)
-                lg_labels.append(labelDB[3])
+                if len(self.lmiss_ax4.get_xdata()):
+                    lg_handles.append(self.lmiss_ax4)
+                    lg_labels.append(labelDB[3])
 
             # Continuous Line Datalogger
             lg_handles.append(self.l1_ax2)


### PR DESCRIPTION
This is a simple change so that missing meteo data marker is not added to the legend if there is no missing data.

![image](https://user-images.githubusercontent.com/10170372/113195923-e00d8500-9230-11eb-83b2-9885e7b3421e.png)
