### PR TITLE
PR: Correctly convert mrc periods from time indexes to xls dates

### DIFF
--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -454,10 +454,13 @@ class WLDataFrameHDF5(WLDataFrameBase):
             self.dset.file.flush()
         if self.dset['mrc/peak_indx'].dtype != np.dtype('float64'):
             # We need to convert peak_indx data to the format used in
-            # GWHAT >= 0.5.1. See jnsebgosselin/gwhat#370.
+            # gwhat >= 0.5.1, where we store the mrc periods as a series of
+            # xldates instead of time indexes. See jnsebgosselin/gwhat#370.
             print('Convert peak_inx values to the new format '
                   'used in gwhat >= 0.5.1.')
-            peak_indx = self.dset['mrc/peak_indx'][...].astype(float)
+
+            peak_indx = self.dset['mrc/peak_indx'][...].astype(int)
+            peak_indx = self.xldates[peak_indx]
 
             # The only way to do that in HDF5 is to delete the dataset and
             # create a new one with the right dtype.

--- a/gwhat/projet/tests/test_project.py
+++ b/gwhat/projet/tests/test_project.py
@@ -453,18 +453,24 @@ def test_mrc_backward_compatibility(project, testfile):
     # is why the 33000 was clipped to 32767.
 
     # Fetch the test waterlevel dataset again from the project and make sure
-    # that the peak_indx data were converted as expected to float64.
+    # that the peak_indx data were converted as expected to float64 and as
+    # xls numerical dates instead of time indexes of the time series.
     wldset = project.get_wldset('dataset_test')
     assert wldset['mrc/peak_indx'].dtype == np.dtype('float64')
-    assert wldset['mrc/peak_indx'].tolist() == [2, 17, 100, 30000, 32767]
+    assert wldset['mrc/peak_indx'].tolist() == wldset.xldates[
+        [2, 17, 100, 30000, 32767]].tolist()
 
     # Make sure the data are formatted as expected when fetched.
     mrc_data = wldset.get_mrc()
     assert np.isnan(mrc_data['params']).tolist() == [True, True]
-    assert mrc_data['peak_indx'] == [(2, 17), (100, 30000)]
+    assert mrc_data['peak_indx'] == [
+        (wldset.xldates[2], wldset.xldates[17]),
+        (wldset.xldates[100], wldset.xldates[30000])]
+
     assert mrc_data['time'].tolist() == []
     assert mrc_data['recess'].tolist() == []
 
 
 if __name__ == "__main__":
-    pytest.main(['-x', __file__, '-v', '-rw'])
+    pytest.main(['-x', __file__, '-v', '-rw',
+                 '-k', 'test_mrc_backward_compatibility'])

--- a/gwhat/projet/tests/test_project.py
+++ b/gwhat/projet/tests/test_project.py
@@ -425,6 +425,7 @@ def test_mrc_backward_compatibility(project, testfile):
     with GWHAT version 0.5.0 and older.
 
     See jnsebgosselin/gwhat#370.
+    See jnsebgosselin/gwhat#377.
     """
     # Add the dataset to the test project.
     project.add_wldset('dataset_test', WLDataFrame(testfile))


### PR DESCRIPTION
Following the changes that were made in PR#370, we need to convert the time indexes that are used to define the MRC periods to actual xls dates.