### PR TITLE
PR: upgrade numpy and pyqt versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appconfigs
-pyqt5 == 5.12.*
+pyqt5 == 5.15.*
 xlsxwriter
 xlrd == 1.*
 xlwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ xlsxwriter
 xlrd == 1.*
 xlwt
 cython>=0.25.2
-numpy == 1.16.*
+numpy == 1.19.*
 matplotlib == 3.1.*
 requests
 h5py == 2.10.*


### PR DESCRIPTION
- Upgraded Numpy version from 1.16.* to 1.19.*

The numpy version 1.19.x series is now quite stable. The 1.16.* series is quite old and has not received any update since December 29, 2019. This is going to be a problem when we decide to upgrade the version of Python.

- Upgraded pyqt version from 1.12.* to 1.15.*

The last update of pyqt for the 5.12 series was version 5.12.3 that was released on June 26, 2019. This is a problem if we want to upgrade to Python 3.8, since this version of Python was first release on October 10, 2019.

The 5.15 series is now almost 1 year old and has now received 4 bug fix releases. We can assume it is now quite stable, so I guess it is relatively safe to upgrade the pyqt version that we use to package gwire to the latest release of the 5.25 series.