### PR TITLE
PR: Increase python version in AppVeyor from 3.7 to 3.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
     GWHAT_VERSION: "gwhat_0.5.0"
 
   matrix:
-    - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7"
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"
 
 platform:

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------
 
 # ---- Standard library imports
-from time import clock
+from time import perf_counter
 import csv
 import os
 import os.path as osp
@@ -1634,7 +1634,7 @@ def calculate_mrc(t, h, periods, mrctype=1):
     print('---- MRC calculation started ----')
     print('mrctype = %s' % (['Linear', 'Exponential'][mrctype]))
 
-    tstart = clock()
+    tstart = perf_counter()
 
     # If mrctype is 0, then the parameter A is kept to a value of 0 throughout
     # the entire optimization process and only paramter B is optimized.
@@ -1748,7 +1748,7 @@ def calculate_mrc(t, h, periods, mrctype=1):
         if tol < tolmax:
             break
 
-    tend = clock()
+    tend = perf_counter()
     print('TIME = %0.3f sec' % (tend-tstart))
     print('---- FIN ----')
 

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -155,13 +155,14 @@ class HydroprintGUI(QWidget):
             triggered=self.zoom_in,
             iconsize=get_iconsize('normal')
             )
-        self.zoom_disp = QSpinBox()
+        self.zoom_disp = QDoubleSpinBox()
         self.zoom_disp.setAlignment(Qt.AlignCenter)
         self.zoom_disp.setButtonSymbols(QAbstractSpinBox.NoButtons)
         self.zoom_disp.setReadOnly(True)
         self.zoom_disp.setSuffix(' %')
         self.zoom_disp.setRange(0, 9999)
         self.zoom_disp.setValue(100)
+        self.zoom_disp.setDecimals(0)
         self.hydrograph_scrollarea.zoomChanged.connect(self.zoom_disp.setValue)
 
         zoom_pan = QFrame()

--- a/gwhat/HydroPrint2.py
+++ b/gwhat/HydroPrint2.py
@@ -1046,7 +1046,7 @@ class PageSetupWin(QWidget):
 
             wp = parent.frameGeometry().width()
             hp = parent.frameGeometry().height()
-            cp = parent.mapToGlobal(QPoint(wp/2, hp/2))
+            cp = parent.mapToGlobal(QPoint(wp // 2, hp // 2))
         else:
             cp = QDesktopWidget().availableGeometry().center()
 

--- a/gwhat/gwrecharge/gwrecharge_plot_results.py
+++ b/gwhat/gwrecharge/gwrecharge_plot_results.py
@@ -662,13 +662,14 @@ class FigureManager(QWidget):
             triggered=self.figviewer.zoomIn
             )
 
-        self.zoom_disp = QSpinBox()
+        self.zoom_disp = QDoubleSpinBox()
         self.zoom_disp.setAlignment(Qt.AlignCenter)
         self.zoom_disp.setButtonSymbols(QAbstractSpinBox.NoButtons)
         self.zoom_disp.setReadOnly(True)
         self.zoom_disp.setSuffix(' %')
         self.zoom_disp.setRange(0, 9999)
         self.zoom_disp.setValue(100)
+        self.zoom_disp.setDecimals(0)
         self.figviewer.zoomChanged.connect(self.zoom_disp.setValue)
 
         zoom_pan = QFrame()

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -1036,7 +1036,7 @@ def load_dict_from_h5grp(h5grp):
             try:
                 len(values)
             except TypeError:
-                values = np.asscalar(values)
+                values = values.item()
             dic[key] = values
         elif isinstance(item, h5py._hl.group.Group):
             dic[key] = load_dict_from_h5grp(item)

--- a/gwhat/tests/test_hydrocalc.py
+++ b/gwhat/tests/test_hydrocalc.py
@@ -65,11 +65,9 @@ def hydrocalc(datamanager, qtbot):
 
 
 # ---- Test WLCalc
-@pytest.mark.run(order=9)
 def test_hydrocalc_init(hydrocalc, mocker):
     assert hydrocalc
 
 
 if __name__ == "__main__":
-    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])
-    # pytest.main()
+    pytest.main(['-x', __file__, '-v', '-rw'])

--- a/gwhat/tests/test_hydroprint.py
+++ b/gwhat/tests/test_hydroprint.py
@@ -118,13 +118,13 @@ def test_autoplot_hydroprint(hydroprint):
 def test_zoomin_zoomout(hydroprint):
     """Test zooming in and out the graph."""
     # Test zoom in.
-    expected_values = [100, 120, 144, 172, 172]
+    expected_values = [100, 120, 144, 173, 173]
     for expected_value in expected_values:
         assert hydroprint.zoom_disp.value() == expected_value
         hydroprint.zoom_in()
 
     # Test zoom out.
-    expected_values = [172, 144, 120, 100, 83, 69, 57, 57]
+    expected_values = [173, 144, 120, 100, 83, 69, 58, 58]
     for expected_value in expected_values:
         assert hydroprint.zoom_disp.value() == expected_value
         hydroprint.zoom_out()


### PR DESCRIPTION
From https://www.python.org/downloads/release/python-3710/:

> Python 3.9 is now the latest feature release series of Python 3. Get the latest release of 3.9.x here. Python 3.7.8 was the last bugfix release for 3.7 and 3.7.9 was the last release to provide binary installers for Windows and macOS. Python 3.7 is now in the security fix phase of its life cycle. Only security-related issues are accepted and addressed during this phase. We plan to provide security fixes for Python 3.7 as needed until mid 2023, five years following its initial release. Security fix releases are produced periodically as needed and are source-only releases.

In order to package GWHAT with the latest security patches, I think that we need to upgrade our version of Python to 3.8.