### PR TITLE
PR: Fix CI and upgrade numpy and pandas dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,9 @@ install:
       
   # Setup SYS PATH.
   - cmd: set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+  
+  # Upgrade pip.
+  - python -m pip install --upgrade pip
 
   # Setup GWHAT dev requirements.
   - python -m pip install -r requirements-dev.txt


### PR DESCRIPTION
We need to upgrade pip or else installation of  `pyqt5==5.15.6` fails on Python 3.8.