### PR TITLE
PR: Upgrade numpy and pandas

### DIFF
--- a/gwhat/projet/manager_projet.py
+++ b/gwhat/projet/manager_projet.py
@@ -31,7 +31,6 @@ from gwhat.projet.reader_projet import ProjetReader
 from gwhat.utils import icons
 from gwhat.projet.manager_data import DataManager
 from gwhat.projet.project_selector import ProjectSelector
-from gwhat.projet.reader_waterlvl import init_waterlvl_measures
 import gwhat.common.widgets as myqt
 from gwhat.widgets.layout import VSep, HSep
 from gwhat import __namever__
@@ -192,7 +191,6 @@ class ProjetManager(QWidget):
                     self.close_projet()
                     return False
 
-        init_waterlvl_measures(osp.join(self.projet.dirname, "Water Levels"))
         self.project_selector.add_recent_project(self.projet.filename)
         self.project_selector.set_current_project(self.projet.filename)
         self.project_selector.adjustSize()

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -194,14 +194,14 @@ def init_waterlvl_measures(dirname):
     if it does not already exist.
     """
     for ext in FILE_EXTS:
-        fname = os.path.join(dirname, "waterlvl_manual_measurements" + ext)
-        if os.path.exists(fname):
+        fname = osp.join(dirname, "waterlvl_manual_measurements" + ext)
+        if osp.exists(fname):
             return
     else:
         fname = os.path.join(dirname, 'waterlvl_manual_measurements.csv')
         fcontent = [['Well_ID', 'Time (days)', 'Obs. (mbgs)']]
 
-        if not os.path.exists(dirname):
+        if not osp.exists(dirname):
             os.makedirs(dirname)
         save_content_to_csv(fname, fcontent)
 

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -20,8 +20,7 @@ from collections.abc import Mapping
 import numpy as np
 import pandas as pd
 import xlrd
-from xlrd.xldate import xldate_from_datetime_tuple
-from xlrd import xldate_as_tuple
+import openpyxl
 
 # ---- Local library imports
 from gwhat.common.utils import save_content_to_csv
@@ -127,11 +126,20 @@ def open_water_level_datafile(filename):
     if ext == '.csv':
         with open(filename, 'r', encoding='utf8') as f:
             data = list(csv.reader(f, delimiter=','))
-    elif ext in ['.xls', '.xlsx']:
+    elif ext == '.xls':
         with xlrd.open_workbook(filename, on_demand=True) as wb:
             sheet = wb.sheet_by_index(0)
             data = [sheet.row_values(rowx, start_colx=0, end_colx=None) for
                     rowx in range(sheet.nrows)]
+    elif ext == '.xlsx':
+        try:
+            workbook = openpyxl.load_workbook(filename)
+            sheet = workbook[workbook.sheetnames[0]]
+            data = [list(row_values) for row_values in
+                    sheet.iter_rows(min_col=1, values_only=True)]
+        finally:
+            workbook.close()
+        print(data)
 
     return data
 

--- a/gwhat/projet/reader_waterlvl.py
+++ b/gwhat/projet/reader_waterlvl.py
@@ -220,10 +220,7 @@ def load_waterlvl_measures(filename, well):
         if os.path.exists(root + ext):
             break
     else:
-        # The file does not exists, so we generate an empty file with
-        # a header.
         print("done")
-        init_waterlvl_measures(os.path.dirname(root))
         return np.array([]), np.array([])
 
     # Open and read the file.

--- a/gwhat/tests/test_hydroprint.py
+++ b/gwhat/tests/test_hydroprint.py
@@ -83,14 +83,8 @@ def pagesetup(qtbot):
 
 
 # ---- Test HydroprintGUI
-def test_hydroprint_init(hydroprint, mocker, qtbot, projectpath):
-    """Test the initialization of the hydroprint plugin."""
-    # Assert that the water_level_measurement file was initialize correctly.
-    output_dir = os.path.join(projectpath, "Water Levels")
-    filename = os.path.join(output_dir, "waterlvl_manual_measurements.csv")
-    assert os.path.exists(filename)
-
-    # Assert that the Page Setup Window is shown correctly.
+def test_hydroprint_page_setup(hydroprint, mocker, qtbot, projectpath):
+    """Test the Page Setup Window is shown correctly."""
     qtbot.mouseClick(hydroprint.btn_page_setup, Qt.LeftButton)
     qtbot.waitForWindowShown(hydroprint.page_setup_win)
 

--- a/gwhat/tests/test_read_waterlvl.py
+++ b/gwhat/tests/test_read_waterlvl.py
@@ -38,8 +38,23 @@ DATA = [['Well name = ', "êi!@':i*"],
         ]
 FILENAME = "water_level_datafile"
 
+delete_file("waterlvl_manual_measurements.csv")
+delete_file("waterlvl_manual_measurements.xls")
+delete_file("waterlvl_manual_measurements.xlsx")
 
-# ---- Pytest Fixtures
+WLMEAS = [['Well_ID', 'Time (days)', 'Obs. (mbgs)'],
+          ['Test', 40623.54167, 1.43],
+          ['Test', 40842.54167, 1.6],
+          ['Test', 41065.54167, 1.57],
+          ['test', 41065.54167, 1.57],
+          ["é@#^'", 41240.8125, 3.75],
+          ['test2', 41402.34375, 3.56],
+          ]
+
+
+# =============================================================================
+# ---- Fixtures
+# =============================================================================
 @pytest.fixture
 def datatmpdir(tmpdir):
     """Create a set of water level datafile in various format."""
@@ -53,7 +68,9 @@ def datatmpdir(tmpdir):
     return str(tmpdir)
 
 
-# ---- Test reading water level datafiles
+# =============================================================================
+# ---- Tests
+# =============================================================================
 @pytest.mark.parametrize("ext", ['.csv', '.xls', '.xlsx'])
 def test_reading_waterlvl(datatmpdir, ext):
     df = WLDataFrame(osp.join(datatmpdir, FILENAME + ext))
@@ -79,23 +96,6 @@ def test_reading_waterlvl(datatmpdir, ext):
     for key in ['WL', 'BP', 'ET']:
         assert np.abs(np.min(df[key] - expected_results[key])) < 10e-6
     assert np.abs(np.min(df.xldates - expected_results['Time'])) < 10e-6
-
-
-# Test water_level_measurements.
-# -------------------------------
-
-delete_file("waterlvl_manual_measurements.csv")
-delete_file("waterlvl_manual_measurements.xls")
-delete_file("waterlvl_manual_measurements.xlsx")
-
-WLMEAS = [['Well_ID', 'Time (days)', 'Obs. (mbgs)'],
-          ['Test', 40623.54167, 1.43],
-          ['Test', 40842.54167, 1.6],
-          ['Test', 41065.54167, 1.57],
-          ['test', 41065.54167, 1.57],
-          ["é@#^'", 41240.8125, 3.75],
-          ['test2', 41402.34375, 3.56],
-          ]
 
 
 def test_init_waterlvl_measures():
@@ -168,4 +168,3 @@ def test_load_waterlvl_measures_withxls():
 
 if __name__ == "__main__":
     pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])
-    # pytest.main()

--- a/gwhat/tests/test_read_waterlvl.py
+++ b/gwhat/tests/test_read_waterlvl.py
@@ -7,7 +7,6 @@
 # Licensed under the terms of the GNU General Public License.
 
 # ---- Standard library imports
-import sys
 import os
 import os.path as osp
 import csv
@@ -15,13 +14,11 @@ import csv
 # ---- Third party imports
 import pytest
 import numpy as np
-import xlsxwriter
 
 # ---- Local library imports
-from gwhat.common.utils import (save_content_to_excel, save_content_to_csv,
-                                delete_file)
+from gwhat.common.utils import save_content_to_excel, save_content_to_csv
 from gwhat.projet.reader_waterlvl import (
-        load_waterlvl_measures, init_waterlvl_measures, WLDataFrame)
+    load_waterlvl_measures, init_waterlvl_measures, WLDataFrame)
 
 DATA = [['Well name = ', "êi!@':i*"],
         ['well id : ', '1234ABC'],
@@ -36,11 +33,6 @@ DATA = [['Well name = ', "êi!@':i*"],
         [41241.70833, 3.665777025, 10.33127437, 387.7404819],
         [41241.71875, 3.665277031, 10.33097437, 396.9950643]
         ]
-FILENAME = "water_level_datafile"
-
-delete_file("waterlvl_manual_measurements.csv")
-delete_file("waterlvl_manual_measurements.xls")
-delete_file("waterlvl_manual_measurements.xlsx")
 
 WLMEAS = [['Well_ID', 'Time (days)', 'Obs. (mbgs)'],
           ['Test', 40623.54167, 1.43],
@@ -56,16 +48,23 @@ WLMEAS = [['Well_ID', 'Time (days)', 'Obs. (mbgs)'],
 # ---- Fixtures
 # =============================================================================
 @pytest.fixture
-def datatmpdir(tmpdir):
+def datatmpdir(tmp_path):
     """Create a set of water level datafile in various format."""
     save_content_to_csv(
-        osp.join(str(tmpdir), FILENAME + '.csv'), DATA)
+        osp.join(tmp_path, 'water_level_datafile.csv'), DATA)
     save_content_to_excel(
-        osp.join(str(tmpdir), FILENAME + '.xls'), DATA)
+        osp.join(tmp_path, 'water_level_datafile.xls'), DATA)
     save_content_to_excel(
-        osp.join(str(tmpdir), FILENAME + '.xlsx'), DATA)
+        osp.join(tmp_path, 'water_level_datafile.xlsx'), DATA)
 
-    return str(tmpdir)
+    save_content_to_csv(
+        osp.join(tmp_path, 'waterlvl_manual_measurements.csv'), WLMEAS)
+    save_content_to_excel(
+        osp.join(tmp_path, 'waterlvl_manual_measurements.xls'), WLMEAS)
+    save_content_to_excel(
+        osp.join(tmp_path, 'waterlvl_manual_measurements.xlsx'), WLMEAS)
+
+    return tmp_path
 
 
 # =============================================================================
@@ -73,20 +72,20 @@ def datatmpdir(tmpdir):
 # =============================================================================
 @pytest.mark.parametrize("ext", ['.csv', '.xls', '.xlsx'])
 def test_reading_waterlvl(datatmpdir, ext):
-    df = WLDataFrame(osp.join(datatmpdir, FILENAME + ext))
+    df = WLDataFrame(osp.join(datatmpdir, 'water_level_datafile' + ext))
 
     expected_results = {
-          'Well': "êi!@':i*",
-          'Well ID': '1234ABC',
-          'Province': 'Qc',
-          'Latitude': 45.36,
-          'Longitude': -72.4234665345,
-          'Elevation': 123,
-          'Municipality': '',
-          'Time': np.array([41241.69792, 41241.70833, 41241.71875]),
-          'WL': np.array([3.667377006, 3.665777025, 3.665277031]),
-          'BP': np.array([10.33327435, 10.33127437, 10.33097437]),
-          'ET': np.array([383.9680352, 387.7404819, 396.9950643])}
+        'Well': "êi!@':i*",
+        'Well ID': '1234ABC',
+        'Province': 'Qc',
+        'Latitude': 45.36,
+        'Longitude': -72.4234665345,
+        'Elevation': 123,
+        'Municipality': '',
+        'Time': np.array([41241.69792, 41241.70833, 41241.71875]),
+        'WL': np.array([3.667377006, 3.665777025, 3.665277031]),
+        'BP': np.array([10.33327435, 10.33127437, 10.33097437]),
+        'ET': np.array([383.9680352, 387.7404819, 396.9950643])}
 
     keys = ['Well', 'Well ID', 'Province', 'Latitude', 'Longitude',
             'Elevation', 'Municipality']
@@ -98,61 +97,40 @@ def test_reading_waterlvl(datatmpdir, ext):
     assert np.abs(np.min(df.xldates - expected_results['Time'])) < 10e-6
 
 
-def test_init_waterlvl_measures():
-    # Assert that the water_level_measurement file is initialized correctly.
-    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements")
-    assert not os.path.exists(filename+'.csv')
+def test_init_waterlvl_measures(tmp_path):
+    """
+    Assert that the water_level_measurement file is initialized correctly.
+    """
+    filename = os.path.join(tmp_path, 'waterlvl_manual_measurements.csv')
+    assert not osp.exists(filename)
+
     time, wl = load_waterlvl_measures(filename, 'Test')
-    assert os.path.exists(filename+'.csv')
+    assert len(time) == 0 and isinstance(time, np.ndarray)
+    assert len(wl) == 0 and isinstance(wl, np.ndarray)
+
+    init_waterlvl_measures(tmp_path)
+    assert osp.exists(filename)
+
+    time, wl = load_waterlvl_measures(filename, 'Test')
     assert len(time) == 0 and isinstance(time, np.ndarray)
     assert len(wl) == 0 and isinstance(wl, np.ndarray)
 
     # Assert that the format of the file is correct.
     expected_result = ['Well_ID', 'Time (days)', 'Obs. (mbgs)']
-    with open(filename+'.csv', 'r') as f:
+    with open(filename, 'r') as f:
         reader = list(csv.reader(f, delimiter=','))
     assert len(reader) == 1
     assert reader[0] == expected_result
 
 
-def test_load_waterlvl_measures_withcsv():
-    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements.csv")
-    save_content_to_csv(filename, WLMEAS)
+@pytest.mark.parametrize("ext", ['.csv', '.xls', '.xlsx'])
+def test_load_waterlvl_measurements(datatmpdir, ext):
+    filename = osp.join(datatmpdir, "waterlvl_manual_measurements" + ext)
 
-    # Test init_waterlvl_measures to be sure the file is not overriden.
-    init_waterlvl_measures(os.getcwd())
-
-    # Assert that it loads the right data.
-    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements")
-    time, wl = load_waterlvl_measures(filename, 'Dummy')
-    assert len(time) == 0 and isinstance(time, np.ndarray)
-    assert len(wl) == 0 and isinstance(wl, np.ndarray)
-
-    time, wl = load_waterlvl_measures(filename, 'Test')
-    assert np.all(time == np.array([40623.54167, 40842.54167, 41065.54167]))
-    assert np.all(wl == np.array([1.43, 1.6, 1.57]))
-
-    time, wl = load_waterlvl_measures(filename, "é@#^'")
-    assert np.all(time == np.array([41240.8125]))
-    assert np.all(wl == np.array([3.75]))
-
-
-def test_load_waterlvl_measures_withxls():
-    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements.csv")
-    delete_file(filename)
-    assert not os.path.exists(filename)
-
-    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements.xlsx")
-    with xlsxwriter.Workbook(filename) as wb:
-        ws = wb.add_worksheet()
-        for i, line in enumerate(WLMEAS):
-            ws.write_row(i, 0, line)
-
-    # Test init_waterlvl_measures to be sure the file is not overriden.
-    init_waterlvl_measures(os.getcwd())
+    # Test that init_waterlvl_measures does not everride an existing file.
+    init_waterlvl_measures(datatmpdir)
 
     # Assert that it loads the right data.
-    filename = os.path.join(os.getcwd(), "waterlvl_manual_measurements")
     time, wl = load_waterlvl_measures(filename, 'Dummy')
     assert len(time) == 0 and isinstance(time, np.ndarray)
     assert len(wl) == 0 and isinstance(wl, np.ndarray)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ xlsxwriter
 xlrd == 1.*
 xlwt
 cython>=0.25.2
-numpy == 1.19.*
+numpy == 1.21.*
 matplotlib == 3.1.*
 requests
 h5py == 2.10.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ matplotlib == 3.1.*
 requests
 h5py == 2.10.*
 qtawesome
-pandas == 0.25.*
+pandas == 1.3.*
 qtpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 appconfigs
 pyqt5 == 5.15.*
+openpyxl
 xlsxwriter
-xlrd == 1.*
+xlrd
 xlwt
 cython>=0.25.2
 numpy == 1.21.*


### PR DESCRIPTION
- Upgrade numpy from 1.19.* tp 1.21.*
- Upgrade pandas from 0.25.* to 1.3.*
-  Cleaned up code to read water level data and manual measurements from Excel files.

Significant improvements were made lately to these two packages, so it is a good idea to upgrade them to a more recent version.