### PR TITLE
PR: Fix export master recession curve results

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -691,8 +691,8 @@ class WLCalc(QWidget, SaveFileMixin):
                 self.dialog_dir,
                 "Well_{}_mrc_results.csv".format(self.wldset['Well']))
 
-        savefilename = self.select_savefilename(
-            "Save MRC results", savefilename, "*.xlsx;;*.xls;;*.csv")
+        filename, filetype = QFileDialog.getSaveFileName(
+            "Save MRC results", filename, 'Text CSV (*.csv)')
         if filename:
             QApplication.setOverrideCursor(Qt.WaitCursor)
             QApplication.processEvents()

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -692,7 +692,8 @@ class WLCalc(QWidget, SaveFileMixin):
                 "Well_{}_mrc_results.csv".format(self.wldset['Well']))
 
         filename, filetype = QFileDialog.getSaveFileName(
-            "Save MRC results", filename, 'Text CSV (*.csv)')
+            self, "Save MRC results", filename, 'Text CSV (*.csv)')
+
         if filename:
             QApplication.setOverrideCursor(Qt.WaitCursor)
             QApplication.processEvents()

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -25,7 +25,7 @@ from PyQt5.QtCore import pyqtSignal as QSignal
 from PyQt5.QtWidgets import (
     QGridLayout, QComboBox, QTextEdit, QSizePolicy, QPushButton, QLabel,
     QTabWidget, QApplication, QWidget, QMainWindow, QToolBar, QFrame,
-    QMessageBox)
+    QMessageBox, QFileDialog)
 
 import matplotlib as mpl
 from matplotlib.widgets import AxesWidget
@@ -433,7 +433,7 @@ class WLCalc(QWidget, SaveFileMixin):
             icon='save',
             iconsize=get_iconsize('normal'),
             tip='Save calculated MRC to file.',
-            triggered=self.save_mrc_tofile)
+            triggered=lambda: self.save_mrc_tofile())
 
         self.btn_MRCalc = QPushButton('Compute MRC')
         self.btn_MRCalc.clicked.connect(self.btn_MRCalc_isClicked)
@@ -684,24 +684,23 @@ class WLCalc(QWidget, SaveFileMixin):
             self.btn_save_mrc.setEnabled(False)
         self.draw_mrc()
 
-    def save_mrc_tofile(self, savefilename=None):
+    def save_mrc_tofile(self, filename=None):
         """Save the master recession curve results to a file."""
-        if savefilename is None:
-            savefilename = osp.join(
+        if filename is None:
+            filename = osp.join(
                 self.dialog_dir,
-                "Well_%s_mrc_results.xlsx" % self.wldset['Well'])
+                "Well_{}_mrc_results.csv".format(self.wldset['Well']))
 
         savefilename = self.select_savefilename(
             "Save MRC results", savefilename, "*.xlsx;;*.xls;;*.csv")
-
-        if savefilename:
+        if filename:
             QApplication.setOverrideCursor(Qt.WaitCursor)
             QApplication.processEvents()
             try:
-                self.wldset.save_mrc_tofile(savefilename)
+                self.wldset.save_mrc_tofile(filename)
             except PermissionError:
                 self.show_permission_error()
-                self.save_mrc_tofile(savefilename)
+                self.save_mrc_tofile(filename)
             QApplication.restoreOverrideCursor()
 
     def undo_mrc_period(self):

--- a/gwhat/tests/test_hydrocalc.py
+++ b/gwhat/tests/test_hydrocalc.py
@@ -12,9 +12,10 @@ import os
 import os.path as osp
 
 # ---- Third Party Libraries Imports
+import numpy as np
 import pytest
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QFileDialog
 
 
 # ---- Local Libraries Imports
@@ -87,6 +88,56 @@ def test_copy_to_clipboard(hydrocalc, qtbot):
 
     qtbot.mouseClick(hydrocalc.btn_copy_to_clipboard, Qt.LeftButton)
     assert not QApplication.clipboard().image().isNull()
+
+
+def test_calc_mrc(hydrocalc, tmp_path, qtbot, mocker):
+    """
+    Test that the tool to calculate the MRC is working as expected.
+    """
+    assert hydrocalc.dformat == 1  # Matplotlib date format
+    hydrocalc.switch_date_format()
+    assert hydrocalc.dformat == 0  # Excel date format
+
+    # Select recession periods on the hydrograph.
+    coordinates = [
+        (41384.260416666664, 41414.114583333336),
+        (41310.385416666664, 41340.604166666664),
+        (41294.708333333336, 41302.916666666664),
+        (41274.5625, 41284.635416666664),
+        (41457.395833333336, 41486.875),
+        (41440.604166666664, 41447.697916666664),
+        (41543.958333333336, 41552.541666666664)]
+    for coord in coordinates:
+        hydrocalc.add_mrcperiod(coord)
+
+    # Calcul the MRC.
+    mrc_data = hydrocalc.wldset.get_mrc()
+    assert np.isnan(mrc_data['params']).all()
+    assert len(mrc_data['peak_indx']) == 0
+    assert len(mrc_data['recess']) == 0
+    assert len(mrc_data['time']) == 0
+
+    hydrocalc.btn_MRCalc_isClicked()
+
+    mrc_data = hydrocalc.wldset.get_mrc()
+    assert abs(mrc_data['params'][0] - 0.06950756951801638) < 10**-5
+    assert abs(mrc_data['params'][1] - 0.2552602547974224) < 10**-5
+    assert len(mrc_data['peak_indx']) == 7
+    assert len(mrc_data['recess']) == 343
+    assert len(mrc_data['time']) == 343
+
+    # Save MRC results to file.
+    outfile = osp.join(tmp_path, 'test_mrc_export')
+    ffilter = "Text CSV (*.csv)"
+    qfdialog_patcher = mocker.patch.object(
+        QFileDialog,
+        'getSaveFileName',
+        return_value=(outfile, ffilter))
+
+    assert not osp.exists(outfile + '.csv')
+    hydrocalc.save_mrc_tofile()
+    assert osp.exists(outfile + '.csv')
+    assert qfdialog_patcher.call_count == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #393

- Fixed the bug where clicking on the button to save the MRC triggered an error.
- Removed the option to save MRC results in a XLSX or XLS file and only support the CSV option.
- Cleaned and optimized the code and added a test.