### PR TITLE
PR: Use a https link instead of a http link to download the KGS_BRF tool

### DIFF
--- a/gwhat/brf_mod/kgs_gui.py
+++ b/gwhat/brf_mod/kgs_gui.py
@@ -106,7 +106,7 @@ class KGSBRFInstaller(QFrame):
 
         print("Installing KGS_BRF software...", end=" ")
         QApplication.setOverrideCursor(Qt.WaitCursor)
-        url = "http://www.kgs.ku.edu/HighPlains/OHP/index_program/KGS_BRF.zip"
+        url = "https://www.kgs.ku.edu/HighPlains/OHP/index_program/KGS_BRF.zip"
         request = requests.get(url)
         zfile = zipfile.ZipFile(io.BytesIO(request .content))
 


### PR DESCRIPTION
Downloading the KGS_BRF tool should be done over a https link, not a http.