### PR TITLE
PR: Make GWHAT message console an independent dialog window

### DIFF
--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -21,7 +21,7 @@ app = create_qapplication()
 from gwhat import __namever__, __appname__
 from gwhat.widgets.splash import SplashScrn
 splash = SplashScrn()
-splash.showMessage("Starting %s..." % __namever__)
+splash.showMessage(f"Starting {__namever__}...")
 
 # ---- Standard library imports
 import platform

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -25,7 +25,7 @@ from multiprocessing import freeze_support
 # ---- Third party imports
 from qtpy.QtCore import QObject, Signal, QUrl
 from PyQt5.QtGui import QDesktopServices
-from qtpy.QtWidgets import QMainWindow, QWidget, QGridLayout, QTextBrowser
+from qtpy.QtWidgets import QMainWindow, QWidget, QGridLayout
 
 # ---- Local imports
 from gwhat import __namever__, __appname__, __project_url__
@@ -90,12 +90,6 @@ class MainWindow(QMainWindow):
         Setup the GUI of the main window.
         """
         self.show_splash_message("Initializing main window...")
-
-        # Setup the main console.
-        self.main_console = QTextBrowser()
-        self.main_console.setReadOnly(True)
-        self.main_console.setLineWrapMode(QTextBrowser.NoWrap)
-        self.main_console.setOpenExternalLinks(True)
 
         # Setup mainwindow tab widget.
         self.tab_widget = TabWidget()

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -24,6 +24,7 @@ splash = SplashScrn()
 splash.showMessage(f"Starting {__namever__}...")
 
 # ---- Standard library imports
+import os
 import platform
 import sys
 import traceback
@@ -31,14 +32,14 @@ from time import ctime
 from multiprocessing import freeze_support
 
 # ---- Third party imports
-from qtpy.QtCore import Qt, QObject, Signal
-from qtpy.QtWidgets import (
-    QMainWindow, QTextEdit, QSplitter, QWidget, QGridLayout, QTextBrowser)
+from qtpy.QtCore import QObject, Signal, QUrl
+from PyQt5.QtGui import QDesktopServices
+from qtpy.QtWidgets import QMainWindow, QWidget, QGridLayout
 
 # ---- Local imports
+from gwhat import __project_url__
 from gwhat.config.main import CONF
 from gwhat.config.ospath import save_path_to_configs, get_path_from_configs
-
 import gwhat.HydroPrint2 as HydroPrint
 import gwhat.HydroCalc2 as HydroCalc
 from gwhat.widgets.about import AboutWhat
@@ -47,7 +48,8 @@ from gwhat.projet.manager_projet import ProjetManager
 from gwhat.projet.manager_data import DataManager
 from gwhat.utils import icons
 from gwhat.utils.qthelpers import (
-    qbytearray_to_hexstate, hexstate_to_qbytearray)
+    create_toolbutton, qbytearray_to_hexstate, hexstate_to_qbytearray)
+
 
 freeze_support()
 
@@ -116,6 +118,16 @@ class MainWindow(QMainWindow):
             tip='About GWHAT...',
             triggered=lambda: self.show_about_dialog())
         self.tab_widget.add_button(self.about_btn)
+
+        # Setup report bug button.
+        self.bug_btn = create_toolbutton(
+            self,
+            icon='report_bug',
+            text="Report...",
+            tip='Report issue...',
+            triggered=lambda: QDesktopServices.openUrl(
+                QUrl(__project_url__ + "/issues")))
+        self.tab_widget.add_button(self.bug_btn)
 
         msg = '<font color=black>Thanks for using %s.</font>' % __appname__
         self.write2console(msg)

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -77,7 +77,7 @@ class MainWindow(QMainWindow):
         self.dmanager.sig_new_console_msg.connect(self.write2console)
 
         # Generate the GUI.
-        self.__initUI__()
+        self.setup()
         splash.finish(self)
         self._restore_window_geometry()
         self._restore_window_state()
@@ -89,11 +89,10 @@ class MainWindow(QMainWindow):
             self.tab_hydrograph.setEnabled(False)
             self.tab_hydrocalc.setEnabled(False)
 
-    def __initUI__(self):
+    def setup(self):
         """
         Setup the GUI of the main window.
         """
-        # Setup the main console.
         splash.showMessage("Initializing main window...")
         self.main_console = QTextBrowser()
         self.main_console.setReadOnly(True)
@@ -103,6 +102,9 @@ class MainWindow(QMainWindow):
         fontsize = CONF.get('main', 'fontsize_console')
         self.main_console.setStyleSheet(
             "QWidget {font-style: Regular; font-size: %s;}" % fontsize)
+        # Setup mainwindow tab widget.
+        self.tab_widget = TabWidget()
+        self.tab_widget.setCornerWidget(self.pmanager)
 
         msg = '<font color=black>Thanks for using %s.</font>' % __appname__
         self.write2console(msg)
@@ -115,21 +117,19 @@ class MainWindow(QMainWindow):
         splash.showMessage("Initializing plot hydrograph...")
         self.tab_hydrograph = HydroPrint.HydroprintGUI(
             self.dmanager, parent=self)
+        self.tab_widget.addTab(self.tab_hydrograph, 'Plot Hydrograph')
         self.tab_hydrograph.ConsoleSignal.connect(self.write2console)
 
         # Setup the tab analyse hydrograph.
         splash.showMessage("Initializing analyse hydrograph...")
         self.tab_hydrocalc = HydroCalc.WLCalc(self.dmanager)
+        self.tab_widget.addTab(self.tab_hydrocalc, 'Analyze Hydrograph')
         self.tab_hydrocalc.tools['mrc'].sig_new_mrc.connect(
             self.tab_hydrograph.mrc_wl_changed)
         self.tab_hydrocalc.rechg_eval_widget.sig_new_gluedf.connect(
             self.tab_hydrograph.glue_wl_changed)
 
         # Add each tab to the tab widget.
-        self.tab_widget = TabWidget()
-        self.tab_widget.addTab(self.tab_hydrograph, 'Plot Hydrograph')
-        self.tab_widget.addTab(self.tab_hydrocalc, 'Analyze Hydrograph')
-        self.tab_widget.setCornerWidget(self.pmanager)
         self.tab_widget.currentChanged.connect(self.sync_datamanagers)
         self.tab_widget.setCurrentIndex(
             CONF.get('main', 'mainwindow_current_tab'))
@@ -149,9 +149,9 @@ class MainWindow(QMainWindow):
         main_widget = QWidget()
         self.setCentralWidget(main_widget)
 
-        mainGrid = QGridLayout(main_widget)
-        mainGrid.addWidget(self._splitter, 0, 0)
-        mainGrid.addWidget(
+        main_grid = QGridLayout(main_widget)
+        main_grid.addWidget(self.tab_widget, 0, 0)
+        main_grid.addWidget(
             self.tab_hydrocalc.rechg_eval_widget.progressbar, 3, 0)
 
     def write2console(self, text):

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -177,6 +177,19 @@ class MainWindow(QMainWindow):
         main_grid.addWidget(
             self.tab_hydrocalc.rechg_eval_widget.progressbar, 3, 0)
 
+    def show_about_dialog(self):
+        """
+        Create and show the About GWHAT window when the about button
+        is clicked.
+        """
+        pytesting = os.environ.get('GWHAT_PYTEST', 'False') == 'True'
+        if self.about_win is None:
+            self.about_win = AboutWhat(self, pytesting)
+        if pytesting:
+            self.about_win.show()
+        else:
+            self.about_win.exec_()
+
     def write2console(self, text):
         """
         This function is the bottle neck through which all messages writen
@@ -225,6 +238,8 @@ class MainWindow(QMainWindow):
         self.dmanager.close()
 
         print('Closing GWHAT')
+        if self.about_win is not None:
+            self.about_win.close()
         self.tab_hydrocalc.close()
         self.tab_hydrograph.close()
         event.accept()

--- a/gwhat/mainwindow.py
+++ b/gwhat/mainwindow.py
@@ -41,6 +41,7 @@ from gwhat.config.ospath import save_path_to_configs, get_path_from_configs
 
 import gwhat.HydroPrint2 as HydroPrint
 import gwhat.HydroCalc2 as HydroCalc
+from gwhat.widgets.about import AboutWhat
 from gwhat.widgets.tabwidget import TabWidget
 from gwhat.projet.manager_projet import ProjetManager
 from gwhat.projet.manager_data import DataManager
@@ -105,6 +106,16 @@ class MainWindow(QMainWindow):
         # Setup mainwindow tab widget.
         self.tab_widget = TabWidget()
         self.tab_widget.setCornerWidget(self.pmanager)
+
+        # Setup About GWHAT.
+        self.about_win = None
+        self.about_btn = create_toolbutton(
+            self,
+            icon='info',
+            text="About...",
+            tip='About GWHAT...',
+            triggered=lambda: self.show_about_dialog())
+        self.tab_widget.add_button(self.about_btn)
 
         msg = '<font color=black>Thanks for using %s.</font>' % __appname__
         self.write2console(msg)

--- a/gwhat/tests/test_mainwindow.py
+++ b/gwhat/tests/test_mainwindow.py
@@ -14,6 +14,7 @@ os.environ['GWHAT_PYTEST'] = 'True'
 
 # ---- Third party imports
 import pytest
+from qtpy.QtCore import Qt
 
 # ---- Local imports
 from gwhat import __rootdir__
@@ -43,11 +44,11 @@ def mainwindow(qtbot, mocker):
     mocker.patch.object(QMessageBox, 'exec_', return_value=QMessageBox.Ok)
 
     mainwindow = MainWindow()
-    # qtbot.addWidget(mainwindow)
     mainwindow.show()
     qtbot.waitExposed(mainwindow)
 
-    return mainwindow
+    yield mainwindow
+    mainwindow.close()
 
 
 # =============================================================================
@@ -90,6 +91,20 @@ def test_restart_mainwindow(mainwindow, qtbot, mocker, project):
     assert mainwindow.pmanager.projet.filename == project.filename
     assert (get_path_from_configs('main', 'last_project_filepath') ==
             project.filename)
+
+
+def test_about_window(mainwindow, qtbot):
+    """Test the showing and closing of the About GWHAT window."""
+    assert mainwindow.about_win is None
+
+    # Show about window and assert it was created and showed correctly.
+    qtbot.mouseClick(mainwindow.about_btn, Qt.LeftButton)
+    assert mainwindow.about_win
+    assert mainwindow.about_win.isVisible()
+
+    # Close the about window and assert it was closed correctly.
+    qtbot.mouseClick(mainwindow.about_win.ok_btn, Qt.LeftButton)
+    assert not mainwindow.about_win.isVisible()
 
 
 if __name__ == "__main__":

--- a/gwhat/tests/test_tabwidget.py
+++ b/gwhat/tests/test_tabwidget.py
@@ -47,27 +47,6 @@ def worker_updates_bot(qtbot):
     return worker_updates, qtbot
 
 
-# Tests AboutWhat
-# -------------------------------
-
-
-def test_tabwidget_and_about_window(tabwidget_bot):
-    """Test the showing and closing of the About GWHAT window."""
-    tabwidget, qtbot = tabwidget_bot
-    tabwidget.show()
-
-    assert tabwidget.about_win is None
-
-    # Show about window and assert it was created and showed correctly.
-    qtbot.mouseClick(tabwidget.about_btn, Qt.LeftButton)
-    qtbot.addWidget(tabwidget.about_btn)
-    assert tabwidget.about_win
-    assert tabwidget.about_win.isVisible()
-
-    # Close the about window and assert it was closed correctly.
-    qtbot.mouseClick(tabwidget.about_win.ok_btn, Qt.LeftButton)
-    assert not tabwidget.about_win.isVisible()
-
 
 # Tests ManagerUpdates and WorkerUpdates
 # --------------------------------------

--- a/gwhat/tests/test_tabwidget.py
+++ b/gwhat/tests/test_tabwidget.py
@@ -7,22 +7,12 @@
 # Licensed under the terms of the GNU General Public License.
 # -----------------------------------------------------------------------------
 
-# ---- Standard library imports
-import sys
-import os
-import os.path as osp
-sys.path.append(osp.dirname(osp.dirname(osp.realpath(__file__))))
-
 # ---- Third parties imports
 import pytest
-from flaky import flaky
-from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget
 
 # ---- Local imports
 from gwhat.widgets.tabwidget import TabWidget
-from gwhat.widgets.updates import WorkerUpdates
-import gwhat.widgets.updates
 
 
 # =============================================================================
@@ -40,71 +30,9 @@ def tabwidget_bot(qtbot):
     return tabwidget, qtbot
 
 
-@pytest.fixture
-def worker_updates_bot(qtbot):
-    worker_updates = WorkerUpdates()
-    return worker_updates, qtbot
-
-
 # =============================================================================
 # ---- Tests
 # =============================================================================
-@flaky(max_runs=3)
-@pytest.mark.skipif(not os.name == 'nt', reason="It fails often on Travis")
-def test_worker_updates(worker_updates_bot):
-    """
-    Assert that the worker to check for updates on the GitHub API is
-    working as expected.
-    """
-    worker_updates, qtbot = worker_updates_bot
-
-    gwhat.widgets.updates.__version__ = "0.1.0"
-    worker_updates.start()
-    qtbot.waitSignal(worker_updates.sig_ready)
-    assert worker_updates.error is None
-    assert worker_updates.update_available is True
-
-    gwhat.widgets.updates.__version__ = "0.1.0.dev"
-    worker_updates.start()
-    qtbot.waitSignal(worker_updates.sig_ready)
-    assert worker_updates.error is None
-    assert worker_updates.update_available is False
-
-    gwhat.widgets.updates.__version__ = "10.0.0"
-    worker_updates.start()
-    qtbot.waitSignal(worker_updates.sig_ready)
-    assert worker_updates.error is None
-    assert worker_updates.update_available is False
-
-
-@flaky(max_runs=3)
-def test_update_manager(tabwidget_bot):
-    tabwidget, qtbot = tabwidget_bot
-    tabwidget.show()
-
-    # Show about window.
-    qtbot.mouseClick(tabwidget.about_btn, Qt.LeftButton)
-    qtbot.addWidget(tabwidget.about_win)
-
-    # Click on the button to check for updates and assert that the manager
-    # is initialized and showed correctly.
-    assert tabwidget.about_win.manager_updates is None
-
-    qtbot.mouseClick(tabwidget.about_win.btn_check_updates, Qt.LeftButton)
-    assert tabwidget.about_win.manager_updates
-    qtbot.addWidget(tabwidget.about_win.manager_updates)
-
-    qtbot.waitSignal(
-        tabwidget.about_win.manager_updates.thread_updates.started)
-    qtbot.waitSignal(
-        tabwidget.about_win.manager_updates.worker_updates.sig_ready)
-    qtbot.waitSignal(
-        tabwidget.about_win.manager_updates.thread_updates.finished)
-    qtbot.waitUntil(
-        lambda: not tabwidget.about_win.manager_updates.thread_updates.isRunning(),
-        timeout=10000)
-
-
 def test_tabwidget_index_memory(tabwidget_bot):
     tabwidget, qtbot = tabwidget_bot
     tabwidget.show()
@@ -120,5 +48,4 @@ def test_tabwidget_index_memory(tabwidget_bot):
 
 
 if __name__ == "__main__":
-    pytest.main(['-x', osp.basename(__file__), '-v', '-rw'])
-    # pytest.main()
+    pytest.main(['-x', __file__, '-v', '-rw'])

--- a/gwhat/tests/test_tabwidget.py
+++ b/gwhat/tests/test_tabwidget.py
@@ -1,40 +1,39 @@
 # -*- coding: utf-8 -*-
-"""
-Created on Fri Aug  4 01:50:50 2017
-@author: jsgosselin
-"""
+# -----------------------------------------------------------------------------
+# Copyright © GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+# -----------------------------------------------------------------------------
 
 # ---- Standard library imports
-
 import sys
-import os.path
-sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+import os
+import os.path as osp
+sys.path.append(osp.dirname(osp.dirname(osp.realpath(__file__))))
 
 # ---- Third parties imports
-
 import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget
 
 # ---- Local imports
-
 from gwhat.widgets.tabwidget import TabWidget
 from gwhat.widgets.updates import WorkerUpdates
 import gwhat.widgets.updates
 
 
-# Qt Test Fixtures
-# --------------------------------
-
-
+# =============================================================================
+# ---- Fixtures
+# =============================================================================
 @pytest.fixture
 def tabwidget_bot(qtbot):
     tabwidget = TabWidget()
     tabwidget.addTab(QWidget(), 'Tab#1')
     tabwidget.addTab(QWidget(), 'Tab#2')
     tabwidget.addTab(QWidget(), 'Tab#3')
-    tabwidget._pytesting = True
 
     qtbot.addWidget(tabwidget)
 
@@ -47,11 +46,9 @@ def worker_updates_bot(qtbot):
     return worker_updates, qtbot
 
 
-
-# Tests ManagerUpdates and WorkerUpdates
-# --------------------------------------
-
-
+# =============================================================================
+# ---- Tests
+# =============================================================================
 @flaky(max_runs=3)
 @pytest.mark.skipif(not os.name == 'nt', reason="It fails often on Travis")
 def test_worker_updates(worker_updates_bot):
@@ -97,15 +94,16 @@ def test_update_manager(tabwidget_bot):
     assert tabwidget.about_win.manager_updates
     qtbot.addWidget(tabwidget.about_win.manager_updates)
 
-    qtbot.waitSignal(tabwidget.about_win.manager_updates.thread_updates.started)
-    qtbot.waitSignal(tabwidget.about_win.manager_updates.worker_updates.sig_ready)
-    qtbot.waitSignal(tabwidget.about_win.manager_updates.thread_updates.finished)
-    qtbot.waitUntil(lambda: not tabwidget.about_win.manager_updates.thread_updates.isRunning(),
-                    timeout=10000)
+    qtbot.waitSignal(
+        tabwidget.about_win.manager_updates.thread_updates.started)
+    qtbot.waitSignal(
+        tabwidget.about_win.manager_updates.worker_updates.sig_ready)
+    qtbot.waitSignal(
+        tabwidget.about_win.manager_updates.thread_updates.finished)
+    qtbot.waitUntil(
+        lambda: not tabwidget.about_win.manager_updates.thread_updates.isRunning(),
+        timeout=10000)
 
-
-# Tests TabWidget
-# --------------------------------------
 
 def test_tabwidget_index_memory(tabwidget_bot):
     tabwidget, qtbot = tabwidget_bot
@@ -122,5 +120,5 @@ def test_tabwidget_index_memory(tabwidget_bot):
 
 
 if __name__ == "__main__":
-    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])
+    pytest.main(['-x', osp.basename(__file__), '-v', '-rw'])
     # pytest.main()

--- a/gwhat/tests/test_updates.py
+++ b/gwhat/tests/test_updates.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+# -----------------------------------------------------------------------------
+
+# ---- Third parties imports
+import pytest
+from flaky import flaky
+from qtpy.QtWidgets import QMessageBox
+
+# ---- Local imports
+from gwhat.widgets.updates import WorkerUpdates, ManagerUpdates
+import gwhat.widgets.updates
+
+
+# =============================================================================
+# ---- Fixtures
+# =============================================================================
+@pytest.fixture
+def update_worker(qtbot):
+    update_worker = WorkerUpdates()
+    return update_worker
+
+
+@pytest.fixture
+def update_manager(qtbot):
+    update_manager = ManagerUpdates()
+    return update_manager
+
+
+# =============================================================================
+# ---- Tests
+# =============================================================================
+@flaky(max_runs=3)
+def test_worker_updates(update_worker, qtbot):
+    """
+    Assert that the worker to check for updates on the GitHub API is
+    working as expected.
+    """
+    gwhat.widgets.updates.__version__ = "0.1.0"
+    update_worker.start()
+    assert update_worker.error is None
+    assert update_worker.update_available is True
+
+    gwhat.widgets.updates.__version__ = "0.1.0.dev"
+    update_worker.start()
+    assert update_worker.error is None
+    assert update_worker.update_available is False
+
+    gwhat.widgets.updates.__version__ = "10.0.0"
+    update_worker.start()
+    assert update_worker.error is None
+    assert update_worker.update_available is False
+
+
+@flaky(max_runs=3)
+def test_update_manager(update_manager, qtbot, mocker):
+    """
+    Test that the widget to check for updates on the GitHub API is
+    working as expected.
+    """
+    qmsgbox_patcher = mocker.patch.object(
+        QMessageBox, 'exec_', return_value=QMessageBox.Ok)
+
+    with qtbot.waitSignal(update_manager.thread_updates.finished):
+        update_manager.start_updates_check()
+    qtbot.waitUntil(
+        lambda: not update_manager.thread_updates.isRunning(),
+        timeout=10000)
+
+    assert qmsgbox_patcher.call_count == 1
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', __file__, '-v', '-rw'])

--- a/gwhat/utils/icons.py
+++ b/gwhat/utils/icons.py
@@ -97,6 +97,9 @@ FA_ICONS = {
                      {'scale_factor': 0.6,
                       'offset': (0.3, 0.3),
                       'color': COLOR}]}],
+    'console': [
+        ('mdi.console',),
+        {'color': COLOR, 'scale_factor': 1.3}],
     'content_duplicate': [
         ('mdi.content-duplicate',),
         {'color': COLOR, 'scale_factor': 1.2}],

--- a/gwhat/widgets/about.py
+++ b/gwhat/widgets/about.py
@@ -90,7 +90,7 @@ class AboutWhat(QDialog):
     @QSlot()
     def _btn_check_updates_isclicked(self):
         """Handles when the button to check for updates is clicked."""
-        self.manager_updates = ManagerUpdates(self, self._pytesting)
+        self.manager_updates = ManagerUpdates(self)
 
     def set_html_in_AboutTextBox(self):
         """Set the text in the About GWHAT text browser widget."""

--- a/gwhat/widgets/about.py
+++ b/gwhat/widgets/about.py
@@ -59,13 +59,12 @@ class AboutWhat(QDialog):
         self.set_html_in_AboutTextBox()
 
         # ---- toolbar
-
         self.ok_btn = QPushButton('OK')
         self.ok_btn.clicked.connect(self.close)
 
         self.btn_check_updates = QPushButton(' Check for Updates ')
         self.btn_check_updates.clicked.connect(
-                self._btn_check_updates_isclicked)
+            self._btn_check_updates_isclicked)
 
         toolbar = QGridLayout()
         toolbar.addWidget(self.btn_check_updates, 0, 1)
@@ -74,7 +73,6 @@ class AboutWhat(QDialog):
         toolbar.setColumnStretch(0, 100)
 
         # ---- Main Grid
-
         grid = QGridLayout()
         grid.setSpacing(10)
 
@@ -99,7 +97,7 @@ class AboutWhat(QDialog):
 
         width = 750
         filename = os.path.join(
-                __rootdir__, 'ressources', 'WHAT_banner_750px.png')
+            __rootdir__, 'ressources', 'WHAT_banner_750px.png')
 
         # http://doc.qt.io/qt-4.8/richtext-html-subset.html
 

--- a/gwhat/widgets/about.py
+++ b/gwhat/widgets/about.py
@@ -38,12 +38,12 @@ class AboutWhat(QDialog):
                             Qt.CustomizeWindowHint |
                             Qt.WindowCloseButtonHint)
 
+        self.manager_updates = ManagerUpdates(self)
+
         self.__initUI__()
 
     def __initUI__(self):
         """Initialize the GUI."""
-        self.manager_updates = None
-
         # ---- AboutTextBox
 
         self.AboutTextBox = QTextBrowser()
@@ -88,7 +88,7 @@ class AboutWhat(QDialog):
     @QSlot()
     def _btn_check_updates_isclicked(self):
         """Handles when the button to check for updates is clicked."""
-        self.manager_updates = ManagerUpdates(self)
+        self.manager_updates.start_updates_check()
 
     def set_html_in_AboutTextBox(self):
         """Set the text in the About GWHAT text browser widget."""

--- a/gwhat/widgets/console.py
+++ b/gwhat/widgets/console.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+#
+# Copyright © 2022 SARDES Project Contributors
+# https://github.com/cgq-qgc/sardes
+#
+# Some parts of this file is a derivative work of the Sardes project that is
+# licensed under the terms of the MIT License.
+# -----------------------------------------------------------------------------
+
+# ---- Standard library imports
+import sys
+import os.path as osp
+import datetime
+
+# ---- Third party imports
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QTextCursor
+from qtpy.QtWidgets import (
+    QApplication, QDialog, QDialogButtonBox, QGridLayout, QPushButton,
+    QTextBrowser, QFileDialog, QMessageBox)
+
+# ---- Local imports
+from gwhat.utils.icons import get_icon
+from gwhat.config.ospath import (
+    get_select_file_dialog_dir, set_select_file_dialog_dir)
+
+
+class StandardStreamConsole(QTextBrowser):
+    """
+    A Qt text edit to hold and show the standard input and output of the
+    Python interpreter.
+    """
+
+    def __init__(self, textmode='plain'):
+        super().__init__()
+        self.setReadOnly(True)
+        self.setOpenExternalLinks(True)
+        self.textmode = textmode
+
+    def write(self, text):
+        self.moveCursor(QTextCursor.End)
+        if self.textmode == 'plain':
+            self.insertPlainText(text)
+        elif self.textmode == 'rich':
+            self.insertHtml(text + '<br>')
+
+
+class StreamConsole(QDialog):
+    """
+    A console to hold, show and manage the standard input and ouput
+    of the Python interpreter.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowFlags(
+            self.windowFlags() &
+            ~Qt.WindowContextHelpButtonHint |
+            Qt.WindowMinMaxButtonsHint)
+        self.setWindowIcon(get_icon('console'))
+        self.setWindowTitle("GWHAT Console")
+        self.setMinimumSize(700, 500)
+
+        self.std_console = StandardStreamConsole(textmode='rich')
+
+        # Setup the dialog button box.
+        self.saveas_btn = QPushButton('Save As')
+        self.saveas_btn.setDefault(False)
+        self.saveas_btn.clicked.connect(lambda checked: self.save_as())
+
+        self.close_btn = QPushButton('Close')
+        self.close_btn.setDefault(True)
+        self.close_btn.clicked.connect(self.close)
+
+        self.copy_btn = QPushButton('Copy')
+        self.copy_btn.setDefault(False)
+        self.copy_btn.clicked.connect(self.copy_to_clipboard)
+
+        button_box = QDialogButtonBox()
+        button_box.addButton(self.close_btn, button_box.AcceptRole)
+        button_box.addButton(self.saveas_btn, button_box.ActionRole)
+        button_box.addButton(self.copy_btn, button_box.ActionRole)
+
+        # self.setCentralWidget(self.std_console)
+        layout = QGridLayout(self)
+        layout.addWidget(self.std_console, 0, 0)
+        layout.addWidget(button_box, 1, 0)
+
+    def write(self, text):
+        self.std_console.write(text)
+
+    def plain_text(self):
+        """
+        Return the content of the console as plain text.
+        """
+        return self.std_console.toPlainText()
+
+    def save_as(self, filename=None):
+        """
+        Save the content of the console to a text file.
+        """
+        if filename is None:
+            now = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+            filename = osp.join(
+                get_select_file_dialog_dir(), f'gwhat_log_{now}.txt')
+        filename, filefilter = QFileDialog.getSaveFileName(
+            self, "Save File", filename, 'Text File (*.txt)')
+        if filename:
+            filename = osp.abspath(filename)
+            set_select_file_dialog_dir(osp.dirname(filename))
+            if not filename.endswith('.txt'):
+                filename += '.txt'
+
+            QApplication.setOverrideCursor(Qt.WaitCursor)
+            QApplication.processEvents()
+            try:
+                with open(filename, 'w') as txtfile:
+                    txtfile.write(self.plain_text())
+            except PermissionError:
+                QApplication.restoreOverrideCursor()
+                QApplication.processEvents()
+                QMessageBox.warning(
+                    self,
+                    'File in Use',
+                    ("The save file operation cannot be completed because "
+                     "the file is in use by another application or user."),
+                    QMessageBox.Ok)
+                self.save_as(filename)
+            else:
+                QApplication.restoreOverrideCursor()
+                QApplication.processEvents()
+
+    def copy_to_clipboard(self):
+        """
+        Copy the content of the console on the clipboard.
+        """
+        QApplication.clipboard().clear()
+        QApplication.clipboard().setText(self.plain_text())
+
+    def show(self):
+        """
+        Override Qt method.
+        """
+        if self.windowState() == Qt.WindowMinimized:
+            self.setWindowState(Qt.WindowNoState)
+        super().show()
+        self.activateWindow()
+        self.raise_()
+
+
+if __name__ == '__main__':
+    from gwhat.utils.qthelpers import create_qapplication
+    app = create_qapplication()
+
+    console = StreamConsole()
+    console.show()
+
+    sys.exit(app.exec_())

--- a/gwhat/widgets/tabwidget.py
+++ b/gwhat/widgets/tabwidget.py
@@ -12,65 +12,35 @@ import copy
 
 # ---- Third party imports
 from PyQt5.QtCore import pyqtSignal as QSignal
-from PyQt5.QtCore import QUrl, QSize
-from PyQt5.QtGui import QDesktopServices
+from PyQt5.QtCore import QSize
 from PyQt5.QtWidgets import (QApplication, QTabWidget, QWidget, QTabBar,
                              QDesktopWidget, QHBoxLayout)
 
 # ---- Local imports
-from gwhat import __project_url__
-from gwhat.widgets.about import AboutWhat
-from gwhat.utils.icons import QToolButtonBase
 from gwhat.utils import icons
-
-GITHUB_ISSUES_URL = __project_url__ + "/issues"
 
 
 class TabWidget(QTabWidget):
     def __init__(self, parent=None):
         super(TabWidget, self).__init__(parent=None)
-        self._pytesting = False
 
-        self.about_win = None
-
-        self.about_btn = QToolButtonBase(icons.get_icon('info'))
-        self.about_btn.setIconSize(icons.get_iconsize('small'))
-        self.about_btn.setFixedSize(32, 32)
-        self.about_btn.setToolTip('About GWHAT...')
-        self.about_btn.clicked.connect(self._about_btn_isclicked)
-
-        self.bug_btn = QToolButtonBase(icons.get_icon('report_bug'))
-        self.bug_btn.setIconSize(icons.get_iconsize('small'))
-        self.bug_btn.setFixedSize(32, 32)
-        self.bug_btn.setToolTip('Report issue...')
-        self.bug_btn.clicked.connect(
-            lambda: QDesktopServices.openUrl(QUrl(GITHUB_ISSUES_URL)))
-
+        self._buttons = []
         self._button_box = QWidget(self)
         layout = QHBoxLayout(self._button_box)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(1)
-        layout.addWidget(self.about_btn)
-        layout.addWidget(self.bug_btn)
 
         tab_bar = TabBar(self, parent)
         self.setTabBar(tab_bar)
         tab_bar.sig_resized.connect(self._move_about_btn)
         tab_bar.sig_tab_layout_changed.connect(self._move_about_btn)
 
-        self.about_btn.raise_()
-
-    def _about_btn_isclicked(self):
-        """
-        Create and show the About GWHAT window when the about button
-        is clicked.
-        """
-        if self.about_win is None:
-            self.about_win = AboutWhat(self, self._pytesting)
-        if self._pytesting:
-            self.about_win.show()
-        else:
-            self.about_win.exec_()
+    def add_button(self, button):
+        """Add the provided button to the tab bar."""
+        button.setIconSize(icons.get_iconsize('small'))
+        button.setFixedSize(32, 32)
+        self._button_box.layout().addWidget(button)
+        self._buttons.append(button)
 
     def resizeEvent(self, event):
         """Qt method override."""
@@ -111,7 +81,9 @@ class TabBar(QTabBar):
 
     def sizeHint(self):
         sizeHint = QTabBar.sizeHint(self)
-        w = sizeHint.width() + self.tabWidget().about_btn.size().width()
+        w = sizeHint.width()
+        for button in self.tabWidget()._buttons:
+            w += button.size().width()
         return QSize(w, 32)
 
     def resizeEvent(self, event):

--- a/gwhat/widgets/tests/test_about.py
+++ b/gwhat/widgets/tests/test_about.py
@@ -38,24 +38,19 @@ def test_about_dialog_updates(about_dialog, qtbot, mocker):
     Test that the button to check for updates in the Aoubt GWHAT dialog
     is working as expected.
     """
-    assert about_dialog.manager_updates is None
-
     # Click on the button to check for updates and assert that the manager
     # is initialized and showed correctly.
-    mocker.patch.object(QMessageBox, 'exec_', return_value=QMessageBox.Ok)
+    qmsgbox_patcher = mocker.patch.object(
+        QMessageBox, 'exec_', return_value=QMessageBox.Ok)
 
-    qtbot.mouseClick(about_dialog.btn_check_updates, Qt.LeftButton)
-    assert about_dialog.manager_updates
-
-    qtbot.waitSignal(
-        about_dialog.manager_updates.thread_updates.started)
-    qtbot.waitSignal(
-        about_dialog.manager_updates.worker_updates.sig_ready)
-    qtbot.waitSignal(
-        about_dialog.manager_updates.thread_updates.finished)
+    signal = about_dialog.manager_updates.thread_updates.finished
+    with qtbot.waitSignal(signal):
+        qtbot.mouseClick(about_dialog.btn_check_updates, Qt.LeftButton)
     qtbot.waitUntil(
         lambda: not about_dialog.manager_updates.thread_updates.isRunning(),
         timeout=10000)
+
+    assert qmsgbox_patcher.call_count == 1
 
 
 if __name__ == "__main__":

--- a/gwhat/widgets/tests/test_about.py
+++ b/gwhat/widgets/tests/test_about.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+# -----------------------------------------------------------------------------
+
+# ---- Third parties imports
+import pytest
+from flaky import flaky
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QMessageBox
+
+# ---- Local imports
+from gwhat.widgets.about import AboutWhat
+
+
+# =============================================================================
+# ---- Fixtures
+# =============================================================================
+@pytest.fixture
+def about_dialog(qtbot):
+    about_dialog = AboutWhat()
+    about_dialog.show()
+    qtbot.waitExposed(about_dialog)
+    qtbot.addWidget(about_dialog)
+    return about_dialog
+
+
+# =============================================================================
+# ---- Tests
+# =============================================================================
+@flaky(max_runs=3)
+def test_about_dialog_updates(about_dialog, qtbot, mocker):
+    """
+    Test that the button to check for updates in the Aoubt GWHAT dialog
+    is working as expected.
+    """
+    assert about_dialog.manager_updates is None
+
+    # Click on the button to check for updates and assert that the manager
+    # is initialized and showed correctly.
+    mocker.patch.object(QMessageBox, 'exec_', return_value=QMessageBox.Ok)
+
+    qtbot.mouseClick(about_dialog.btn_check_updates, Qt.LeftButton)
+    assert about_dialog.manager_updates
+
+    qtbot.waitSignal(
+        about_dialog.manager_updates.thread_updates.started)
+    qtbot.waitSignal(
+        about_dialog.manager_updates.worker_updates.sig_ready)
+    qtbot.waitSignal(
+        about_dialog.manager_updates.thread_updates.finished)
+    qtbot.waitUntil(
+        lambda: not about_dialog.manager_updates.thread_updates.isRunning(),
+        timeout=10000)
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', __file__, '-v', '-rw'])

--- a/gwhat/widgets/updates.py
+++ b/gwhat/widgets/updates.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2014-2018 GWHAT Project Contributors
+# -----------------------------------------------------------------------------
+# Copyright © GWHAT Project Contributors
 # https://github.com/jnsebgosselin/gwhat
 #
 # This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
@@ -18,16 +18,14 @@
 # https://github.com/ipython/ipython
 #
 # See gwhat/__init__.py for more details.
+# -----------------------------------------------------------------------------
 
-
-# ---- Imports: standard libraries
-
+# ---- Standard imports
 import re
 from distutils.version import LooseVersion
 
 
-# ---- Imports: third parties
-
+# ---- Third party imports
 from PyQt5.QtCore import QObject, Qt, QThread
 from PyQt5.QtCore import pyqtSlot as QSlot
 from PyQt5.QtCore import pyqtSignal as QSignal
@@ -35,10 +33,8 @@ from PyQt5.QtGui import QCursor
 from PyQt5.QtWidgets import QApplication, QMessageBox
 import requests
 
-# ---- Imports: local
-
-from gwhat import (__version__, __releases_url__, __releases_api__,
-                   __appname__, __namever__)
+# ---- Local imports
+from gwhat import __version__, __releases_url__, __releases_api__, __namever__
 from gwhat.utils import icons
 
 

--- a/gwhat/widgets/updates.py
+++ b/gwhat/widgets/updates.py
@@ -45,7 +45,7 @@ class ManagerUpdates(QMessageBox):
     """
 
     def __init__(self, parent=None):
-        super(ManagerUpdates, self).__init__(parent)
+        super().__init__(parent)
 
         self.setWindowTitle('GWHAT updates')
         self.setWindowIcon(icons.get_icon('master'))
@@ -63,8 +63,6 @@ class ManagerUpdates(QMessageBox):
         self.worker_updates.moveToThread(self.thread_updates)
         self.thread_updates.started.connect(self.worker_updates.start)
         self.worker_updates.sig_ready.connect(self._receive_updates_check)
-
-        self.start_updates_check()
 
     def start_updates_check(self):
         """Check if updates are available."""

--- a/gwhat/widgets/updates.py
+++ b/gwhat/widgets/updates.py
@@ -44,9 +44,8 @@ class ManagerUpdates(QMessageBox):
     and displays the ressults in a message box.
     """
 
-    def __init__(self, parent=None, pytesting=False):
+    def __init__(self, parent=None):
         super(ManagerUpdates, self).__init__(parent)
-        self._pytesting = pytesting
 
         self.setWindowTitle('GWHAT updates')
         self.setWindowIcon(icons.get_icon('master'))
@@ -104,12 +103,8 @@ class ManagerUpdates(QMessageBox):
                        ) % (__namever__, __releases_url__, url_m, url_t)
         self.setText(msg)
         self.setIcon(icn)
-
         QApplication.restoreOverrideCursor()
-        if self._pytesting is False:
-            self.exec_()
-        else:
-            self.show()
+        self.exec_()
 
 
 class WorkerUpdates(QObject):
@@ -240,4 +235,5 @@ if __name__ == "__main__":
     import sys
     app = QApplication(sys.argv)
     updates_worker = ManagerUpdates()
+    updates_worker.show()
     sys.exit(app.exec_())


### PR DESCRIPTION
The idea is to remove the message console from the mainwindow and to add it as a separate dialog window that can be accessed with a button.

Having the message console as part of the mainwindow is annoying and takes too much space.

![image](https://user-images.githubusercontent.com/10170372/157538181-dac5e6e8-e5e9-44d5-b939-6019789fd2f8.png)
