### PR TITLE
PR: Update pyinstaller version from 4.2 to 4.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ test_script:
 
 after_test:
   # Install requirements for packaging GWHAT.
-  - python -m pip install pyinstaller==4.2 pywin32 tornado
+  - python -m pip install pyinstaller==4.9 pywin32 tornado
 
   # Package GWHAT with PyInstaller.
   - cmd: set PYTHONPATH=C:\projects\gwhat;%PYTHONPATH%


### PR DESCRIPTION
PyInstaller version 4.2 now throws the following error, probably due the a new version of setuptools.

I'm bumping pyinstaller to 4.9 since that is the version I am using in another similar project and it works well.

```python
Traceback (most recent call last):
    File "C:\Python38-x64\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py", line 363, in <module>
      main()
    File "C:\Python38-x64\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py", line 345, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "C:\Python38-x64\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py", line 164, in prepare_metadata_for_build_wheel
      return hook(metadata_directory, config_settings)
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\build_meta.py", line 188, in prepare_metadata_for_build_wheel
      self.run_setup()
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\build_meta.py", line 281, in run_setup
      super(_BuildMetaLegacyBackend,
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\build_meta.py", line 174, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 75, in <module>
      setup(
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\__init__.py", line 87, in setup
      return distutils.core.setup(**attrs)
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\_distutils\core.py", line 122, in setup
      dist.parse_config_files()
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\dist.py", line 850, in parse_config_files
      setupcfg.parse_configuration(
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\config\setupcfg.py", line 167, in parse_configuration
      meta.parse()
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\config\setupcfg.py", line 446, in parse
      section_parser_method(section_options)
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\config\setupcfg.py", line 417, in parse_section
      self[name] = value
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\config\setupcfg.py", line 238, in __setitem__
      value = parser(value)
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\config\setupcfg.py", line 552, in _parse_version
      return expand.version(self._parse_attr(value, self.package_dir, self.root_dir))
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\config\setupcfg.py", line 372, in _parse_attr
      return expand.read_attr(attr_desc, package_dir, root_dir)
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\config\expand.py", line 194, in read_attr
      module = _load_spec(spec, module_name)
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-env-d8egawfk\overlay\Lib\site-packages\setuptools\config\expand.py", line 214, in _load_spec
      spec.loader.exec_module(module)  # type: ignore
    File "<frozen importlib._bootstrap_external>", line 783, in exec_module
    File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
    File "C:\Users\appveyor\AppData\Local\Temp\1\pip-install-y90hekrf\pyinstaller_[509](https://ci.appveyor.com/project/jnsebgosselin/gwhat/builds/43231067#L509)611d9dcc34144b5d009c9e8cdaee5\PyInstaller.py", line 16, in <module>
      from PyInstaller.__main__ import run
  ModuleNotFoundError: No module named 'PyInstaller.__main__'; 'PyInstaller' is not a package
  [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
Encountered error while generating package metadata.
```