### PR TITLE
PR: Improve suggested dataset name when importing water level and weather data

### DIFF
--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -756,7 +756,9 @@ class NewDatasetDialog(QDialog):
                 self._alt.setValue(self._dataset['Elevation'])
                 self._stn_name.setText(self._dataset['Well'])
                 self._sid.setText(self._dataset['Well ID'])
-                dsetname = self._dataset['Well']
+                dsetname = '{} ({})'.format(
+                    self._dataset['Well'],
+                    self._dataset['Well ID'])
             elif self._datatype == 'daily weather':
                 self._prov.setText(self._dataset.metadata['Location'])
                 self._lat.setValue(self._dataset.metadata['Latitude'])

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -767,7 +767,9 @@ class NewDatasetDialog(QDialog):
                 self._stn_name.setText(self._dataset.metadata['Station Name'])
                 self._sid.setText(self._dataset.metadata['Station ID'])
                 dsetname = self._dataset.metadata['Station Name']
-
+                dsetname = '{} ({})'.format(
+                    self._dataset.metadata['Station Name'],
+                    self._dataset.metadata['Station ID'])                
             # We replace the invalid characters to avoid problems when
             # saving the dataset to the hdf5 format.
             for char in INVALID_CHARS:

--- a/gwhat/projet/manager_data.py
+++ b/gwhat/projet/manager_data.py
@@ -769,7 +769,7 @@ class NewDatasetDialog(QDialog):
                 dsetname = self._dataset.metadata['Station Name']
                 dsetname = '{} ({})'.format(
                     self._dataset.metadata['Station Name'],
-                    self._dataset.metadata['Station ID'])                
+                    self._dataset.metadata['Station ID'])
             # We replace the invalid characters to avoid problems when
             # saving the dataset to the hdf5 format.
             for char in INVALID_CHARS:

--- a/gwhat/projet/tests/test_manager_data.py
+++ b/gwhat/projet/tests/test_manager_data.py
@@ -221,8 +221,10 @@ def test_import_multiple_waterlevel_data(datamanager, mocker, qtbot):
         qtbot.mouseClick(new_waterlvl_dialog.btn_ok, Qt.LeftButton)
 
     assert datamanager.wldataset_count() == 1
-    assert datamanager.wldsets_cbox.currentText() == "PO01 - Calixa-Lavallée (3040002)"
-    assert datamanager.get_current_wldset().name == "PO01 - Calixa-Lavallée (3040002)"
+    assert (datamanager.wldsets_cbox.currentText() ==
+            "PO01 - Calixa-Lavallée (3040002)")
+    assert (datamanager.get_current_wldset().name ==
+            "PO01 - Calixa-Lavallée (3040002)")
 
     # Assert that the dataset from the second input data file was loaded
     # as expected.
@@ -245,8 +247,10 @@ def test_import_multiple_waterlevel_data(datamanager, mocker, qtbot):
         qtbot.mouseClick(new_waterlvl_dialog.btn_skip, Qt.LeftButton)
 
     assert datamanager.wldataset_count() == 1
-    assert datamanager.wldsets_cbox.currentText() == "PO01 - Calixa-Lavallée (3040002)"
-    assert datamanager.get_current_wldset().name == "PO01 - Calixa-Lavallée (3040002)"
+    assert (datamanager.wldsets_cbox.currentText() ==
+            "PO01 - Calixa-Lavallée (3040002)")
+    assert (datamanager.get_current_wldset().name ==
+            "PO01 - Calixa-Lavallée (3040002)")
 
     # Assert that the dataset from the second input data file was loaded
     # as expected.

--- a/gwhat/projet/tests/test_manager_data.py
+++ b/gwhat/projet/tests/test_manager_data.py
@@ -72,7 +72,7 @@ def test_import_weather_data(datamanager, mocker, qtbot):
     with qtbot.waitSignal(new_weather_dialog.sig_new_dataset_loaded):
         qtbot.mouseClick(datamanager.btn_load_meteo, Qt.LeftButton)
 
-    assert new_weather_dialog.name == "IBERVILLE"
+    assert new_weather_dialog.name == "IBERVILLE (7023270)"
     assert new_weather_dialog.station_name == "IBERVILLE"
     assert new_weather_dialog.station_id == "7023270"
     assert new_weather_dialog.province == "QUEBEC"
@@ -84,8 +84,8 @@ def test_import_weather_data(datamanager, mocker, qtbot):
     with qtbot.waitSignal(new_weather_dialog.sig_new_dataset_imported):
         qtbot.mouseClick(new_weather_dialog.btn_ok, Qt.LeftButton)
     assert datamanager.wxdataset_count() == 1
-    assert datamanager.wxdsets_cbox.currentText() == "IBERVILLE"
-    assert datamanager.get_current_wxdset().name == "IBERVILLE"
+    assert datamanager.wxdsets_cbox.currentText() == "IBERVILLE (7023270)"
+    assert datamanager.get_current_wxdset().name == "IBERVILLE (7023270)"
 
 
 def test_delete_weather_data(datamanager, mocker, qtbot):
@@ -144,7 +144,7 @@ def test_import_waterlevel_data(datamanager, mocker, qtbot):
         qtbot.mouseClick(datamanager.btn_load_wl, Qt.LeftButton)
 
     assert new_waterlvl_dialog.directory.text() == WLFILENAME
-    assert new_waterlvl_dialog.name == "PO01 - Calixa-Lavallée"
+    assert new_waterlvl_dialog.name == "PO01 - Calixa-Lavallée (3040002)"
     assert new_waterlvl_dialog.station_name == "PO01 - Calixa-Lavallée"
     assert new_waterlvl_dialog.station_id == "3040002"
     assert new_waterlvl_dialog.province == "QC"
@@ -202,7 +202,7 @@ def test_import_multiple_waterlevel_data(datamanager, mocker, qtbot):
         qtbot.mouseClick(datamanager.btn_load_wl, Qt.LeftButton)
 
     assert new_waterlvl_dialog.directory.text() == WLFILENAME
-    assert new_waterlvl_dialog.name == "PO01 - Calixa-Lavallée"
+    assert new_waterlvl_dialog.name == "PO01 - Calixa-Lavallée (3040002)"
     assert new_waterlvl_dialog.station_name == "PO01 - Calixa-Lavallée"
     assert new_waterlvl_dialog.station_id == "3040002"
     assert new_waterlvl_dialog.province == "QC"
@@ -221,13 +221,13 @@ def test_import_multiple_waterlevel_data(datamanager, mocker, qtbot):
         qtbot.mouseClick(new_waterlvl_dialog.btn_ok, Qt.LeftButton)
 
     assert datamanager.wldataset_count() == 1
-    assert datamanager.wldsets_cbox.currentText() == "PO01 - Calixa-Lavallée"
-    assert datamanager.get_current_wldset().name == "PO01 - Calixa-Lavallée"
+    assert datamanager.wldsets_cbox.currentText() == "PO01 - Calixa-Lavallée (3040002)"
+    assert datamanager.get_current_wldset().name == "PO01 - Calixa-Lavallée (3040002)"
 
     # Assert that the dataset from the second input data file was loaded
     # as expected.
     assert new_waterlvl_dialog.directory.text() == WLFILENAME2
-    assert new_waterlvl_dialog.name == "test_well_02"
+    assert new_waterlvl_dialog.name == "test_well_02 (3040002)"
     assert new_waterlvl_dialog.station_name == "test_well_02"
     assert new_waterlvl_dialog.station_id == "3040002"
     assert new_waterlvl_dialog.province == "QC"
@@ -245,13 +245,13 @@ def test_import_multiple_waterlevel_data(datamanager, mocker, qtbot):
         qtbot.mouseClick(new_waterlvl_dialog.btn_skip, Qt.LeftButton)
 
     assert datamanager.wldataset_count() == 1
-    assert datamanager.wldsets_cbox.currentText() == "PO01 - Calixa-Lavallée"
-    assert datamanager.get_current_wldset().name == "PO01 - Calixa-Lavallée"
+    assert datamanager.wldsets_cbox.currentText() == "PO01 - Calixa-Lavallée (3040002)"
+    assert datamanager.get_current_wldset().name == "PO01 - Calixa-Lavallée (3040002)"
 
     # Assert that the dataset from the second input data file was loaded
     # as expected.
     assert new_waterlvl_dialog.directory.text() == WLFILENAME3
-    assert new_waterlvl_dialog.name == "test_well_03"
+    assert new_waterlvl_dialog.name == "test_well_03 (3040003)"
     assert new_waterlvl_dialog.station_name == "test_well_03"
     assert new_waterlvl_dialog.station_id == "3040003"
     assert new_waterlvl_dialog.province == "QC"
@@ -269,8 +269,8 @@ def test_import_multiple_waterlevel_data(datamanager, mocker, qtbot):
         qtbot.mouseClick(new_waterlvl_dialog.btn_ok, Qt.LeftButton)
 
     assert datamanager.wldataset_count() == 2
-    assert datamanager.wldsets_cbox.currentText() == "test_well_03"
-    assert datamanager.get_current_wldset().name == "test_well_03"
+    assert datamanager.wldsets_cbox.currentText() == "test_well_03 (3040003)"
+    assert datamanager.get_current_wldset().name == "test_well_03 (3040003)"
 
     assert not new_waterlvl_dialog.isVisible()
 


### PR DESCRIPTION
Use well name and id when generating the suggested dataset name instead of using the well name only.

![image](https://user-images.githubusercontent.com/10170372/179305137-c6202b01-5310-4e41-bca0-2235dd739469.png)
