### PR TITLE
PR: Fix compute MRC when no recession period is selected

### DIFF
--- a/gwhat/hydrocalc/api.py
+++ b/gwhat/hydrocalc/api.py
@@ -21,6 +21,13 @@ from gwhat.config.main import CONF
 
 
 def wlcalcmethod(func):
+    """
+    A wrapper that bypass a tool func execution if the tool is not registered
+    to hydrocalc.
+
+    This is required in order to test tools or use tools programmatically
+    without having to register them to hydrocalc.
+    """
     @functools.wraps(func)
     def wrapper(tool, *args, **kwargs):
         if not tool.is_registered():

--- a/gwhat/hydrocalc/recession/recession_tool.py
+++ b/gwhat/hydrocalc/recession/recession_tool.py
@@ -14,11 +14,10 @@ import os.path as osp
 
 # ---- Third party imports
 import pandas as pd
-from PyQt5.QtCore import Qt
-from PyQt5.QtCore import pyqtSignal as QSignal
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import (
     QWidget, QComboBox, QTextEdit, QSizePolicy, QPushButton, QGridLayout,
-    QLabel, QApplication, QFileDialog)
+    QLabel, QApplication, QFileDialog, QMessageBox)
 
 # ---- Local imports
 from gwhat.hydrocalc.recession.recession_calc import calculate_mrc
@@ -37,7 +36,7 @@ class MasterRecessionCalcTool(WLCalcTool, SaveFileMixin):
     __tooltip__ = ("A tool to evaluate the master recession curve "
                    "of the hydrograph.")
 
-    sig_new_mrc = QSignal()
+    sig_new_mrc = Signal()
 
     def __init__(self, parent=None):
         WLCalcTool.__init__(self, parent)

--- a/gwhat/hydrocalc/recession/recession_tool.py
+++ b/gwhat/hydrocalc/recession/recession_tool.py
@@ -289,6 +289,12 @@ class MasterRecessionCalcTool(WLCalcTool, SaveFileMixin):
     def calculate_mrc(self):
         if self.wldset is None:
             return
+        if len(self._mrc_period_xdata) == 0:
+            message = (
+                "The MRC cannot be assessed because no recession period has "
+                "been selected on the hydrograph.")
+            QMessageBox.warning(self, 'Warning', message, QMessageBox.Ok)
+            return
 
         QApplication.setOverrideCursor(Qt.WaitCursor)
 

--- a/gwhat/tests/test_hydrocalc.py
+++ b/gwhat/tests/test_hydrocalc.py
@@ -84,6 +84,18 @@ def test_copy_to_clipboard(hydrocalc, qtbot):
     assert not QApplication.clipboard().image().isNull()
 
 
+def test_calc_mrc_if_empty(hydrocalc, tmp_path, qtbot, mocker):
+    """
+    Test that the tool to calculate the MRC is working as expected.
+
+    Regression test for gwhat/issues#415
+    """
+    mrc_tool = hydrocalc.tools['mrc']
+    assert len(mrc_tool._mrc_period_xdata) == 0
+
+    qtbot.mouseClick(mrc_tool.btn_calc_mrc, Qt.LeftButton)
+
+    
 def test_calc_mrc(hydrocalc, tmp_path, qtbot, mocker):
     """
     Test that the tool to calculate the MRC is working as expected.


### PR DESCRIPTION
Add a message when the user try to compute the MRC but no recession period is selected on the hydrograph.

![image](https://user-images.githubusercontent.com/10170372/179509258-a0834f1b-82bd-46c2-8393-3f5c6f9b748b.png)
