### PR TITLE
PR: Fix evaluating recharge with old MRC data (gwhat <= 0.5.0)

### DIFF
--- a/gwhat/gwrecharge/gwrecharge_calc2.py
+++ b/gwhat/gwrecharge/gwrecharge_calc2.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-
-# Copyright © 2014-2018 GWHAT Project Contributors
+# -----------------------------------------------------------------------------
+# Copyright © GWHAT Project Contributors
 # https://github.com/jnsebgosselin/gwhat
 #
 # This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
 # Licensed under the terms of the GNU General Public License.
+# -----------------------------------------------------------------------------
 
 # ---- Stantard imports
 import os

--- a/gwhat/gwrecharge/gwrecharge_gui.py
+++ b/gwhat/gwrecharge/gwrecharge_gui.py
@@ -327,8 +327,8 @@ class RechgEvalWidget(QFrame):
         """Setup the toolbar of the widget. """
         toolbar = QWidget()
 
-        btn_calib = QPushButton('Compute Recharge')
-        btn_calib.clicked.connect(self.btn_calibrate_isClicked)
+        self.calc_rechg_btn = QPushButton('Compute Recharge')
+        self.calc_rechg_btn.clicked.connect(self.btn_calibrate_isClicked)
 
         self.btn_show_result = QToolButtonSmall(get_icon('search'))
         self.btn_show_result.clicked.connect(self.figstack.show)
@@ -337,7 +337,7 @@ class RechgEvalWidget(QFrame):
         self.btn_save_glue = ExportGLUEButton(self.wxdset)
 
         layout = QGridLayout(toolbar)
-        layout.addWidget(btn_calib, 0, 0)
+        layout.addWidget(self.calc_rechg_btn, 0, 0)
         layout.addWidget(self.btn_show_result, 0, 1)
         layout.addWidget(self.btn_save_glue, 0, 3)
         layout.setContentsMargins(10, 0, 10, 0)

--- a/gwhat/gwrecharge/gwrecharge_gui.py
+++ b/gwhat/gwrecharge/gwrecharge_gui.py
@@ -481,7 +481,14 @@ class RechgEvalWidget(QFrame):
             QMessageBox.warning(self, 'Warning', msg, QMessageBox.Ok)
         else:
             self.wldset.clear_glue()
-            self.wldset.save_glue(glue_dataframe)
+            try:
+                self.wldset.save_glue(glue_dataframe)
+            except Exception as e:
+                # We make sure the GLUE data are not saved in an incomplete
+                # state and cause problem when trying to read the
+                # project afterwards.
+                self.wldset.clear_glue()
+                raise(e)
             self.sig_new_gluedf.emit(glue_dataframe)
 
             self.btn_save_glue.set_model(glue_dataframe)

--- a/gwhat/gwrecharge/tests/test_gwrecharge.py
+++ b/gwhat/gwrecharge/tests/test_gwrecharge.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © GWHAT Project Contributors
+# https://github.com/jnsebgosselin/gwhat
+#
+# This file is part of GWHAT (Ground-Water Hydrograph Analysis Toolbox).
+# Licensed under the terms of the GNU General Public License.
+# -----------------------------------------------------------------------------
+
+# ---- Standard library imports
+import os.path as osp
+from shutil import copyfile
+
+# ---- Third party imports
+import pytest
+from PyQt5.QtCore import Qt
+
+# ---- Local library imports
+from gwhat import __rootdir__
+from gwhat.projet.reader_projet import ProjetReader
+from gwhat.gwrecharge.gwrecharge_gui import RechgEvalWidget
+
+
+# =============================================================================
+# ---- Pytest Fixtures
+# =============================================================================
+@pytest.fixture
+def project(tmp_path):
+    fsrc = osp.join(
+        __rootdir__, 'gwrecharge', 'tests', 'test_gwrecharge_project.gwt')
+    fdst = osp.join(
+        tmp_path, 'test_gwrecharge_project.gwt')
+    copyfile(fsrc, fdst)
+    return ProjetReader(fdst)
+
+
+@pytest.fixture()
+def gwrecharge_widget(qtbot, project):
+    gwrecharge_widget = RechgEvalWidget()
+    gwrecharge_widget.set_wldset(project.get_wldset('3040002_15min'))
+    gwrecharge_widget.set_wxdset(project.get_wxdset('Marieville'))
+
+    qtbot.addWidget(gwrecharge_widget)
+    gwrecharge_widget.show()
+    qtbot.waitExposed(gwrecharge_widget)
+
+    return gwrecharge_widget
+
+
+# =============================================================================
+# ---- Tests
+# =============================================================================
+def test_calc_gwrecharge(gwrecharge_widget, project, qtbot):
+    """
+    Test that calculating groundwater recharge is working as expected.
+    """
+    gwrecharge_widget.wldset.clear_glue()
+    assert gwrecharge_widget.wldset.glue_count() == 0
+
+    with qtbot.waitSignal(gwrecharge_widget.sig_new_gluedf, timeout=5000):
+        qtbot.mouseClick(gwrecharge_widget.calc_rechg_btn, Qt.LeftButton)
+
+    assert gwrecharge_widget.wldset.glue_count() == 1
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', __file__, '-v', '-rw'])

--- a/gwhat/projet/reader_projet.py
+++ b/gwhat/projet/reader_projet.py
@@ -1070,6 +1070,10 @@ def save_dict_to_h5grp(h5grp, dic):
     for key, item in dic.items():
         if isinstance(item, dict):
             save_dict_to_h5grp(h5grp.require_group(key), item)
+        elif item is None:
+            # We need to do this to avoid a TypeError.
+            # See jnsebgosselin/gwhat#430
+            h5grp.create_dataset(key, data=np.nan)
         else:
             h5grp.create_dataset(key, data=item)
 


### PR DESCRIPTION
Fixes #430

We can't save `None` values in hdf5 directly, we need to convert them to `np.nan` first.

Also added a test to cover `test_calc_gwrecharge`.