### PR TITLE
PR: Add buttons to move and zoom the x- and y-axis

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -609,6 +609,31 @@ class WLCalc(QWidget, SaveFileMixin):
             ax.set_ylim(ymin=ymin - yoffset, ymax=ymax + yoffset)
         self.draw()
 
+    def move_axis_range(self, direction: str):
+        """
+        Move axis in the specified direction.
+
+        Parameters
+        ----------
+        direction : str
+            The direction in which to move the axis. Valid values are
+            'left', 'right', 'up', and 'down'.
+        """
+        ax = self.fig.axes[0]
+        if direction in ('left', 'right'):
+            xmin, xmax = ax.get_xlim()
+            xoffset = 0.1 * abs(xmax - xmin)
+            if direction == 'right':
+                xoffset *= -1
+            ax.set_xlim(xmin=xmin + xoffset, xmax=xmax + xoffset)
+        elif direction in ('up', 'down'):
+            ymin, ymax = ax.get_ylim()
+            yoffset = 0.025 * abs(ymax - ymin)
+            if direction == 'down':
+                yoffset *= -1
+            ax.set_ylim(ymin=ymin + yoffset, ymax=ymax + yoffset)
+        self.draw()
+
     def setup_axis_range(self, event=None):
         """Setup the range of the x- and y-axis."""
         if self.wldset is not None:

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -296,7 +296,7 @@ class WLCalc(QWidget, SaveFileMixin):
         modif_sc_text = get_shortcuts_native_text('Ctrl+Shift+Up')
         self.move_up_action = create_action(
             self, icon='arrow_up', text="Move up",
-            tip=f"Move vertical axis up ({modif_sc_text} to zoom out).",
+            tip=f"Move vertical axis up ({modif_sc_text} to zoom in).",
             triggered=lambda _: self._on_move_axis_triggered('up'),
             shortcut='Ctrl+Up')
         self.move_up_action.setShortcuts(['Ctrl+Up', 'Ctrl+Shift+Up'])
@@ -304,7 +304,7 @@ class WLCalc(QWidget, SaveFileMixin):
         modif_sc_text = get_shortcuts_native_text('Ctrl+Shift+Down')
         self.move_down_action = create_action(
             self, icon='arrow_down', text="Move down",
-            tip=f"Move vertical axis down ({modif_sc_text} to zoom in).",
+            tip=f"Move vertical axis down ({modif_sc_text} to zoom out).",
             triggered=lambda _: self._on_move_axis_triggered('down'),
             shortcut='Ctrl+Down')
         self.move_down_action.setShortcuts(['Ctrl+Down', 'Ctrl+Shift+Down'])

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -240,10 +240,6 @@ class WLCalc(QWidget, SaveFileMixin):
         self._navig_toolbar = NavigationToolbar2QT(self.canvas, parent=self)
         self._navig_toolbar.hide()
 
-        self.btn_home = QToolButtonNormal(icons.get_icon('home'))
-        self.btn_home.setToolTip('Reset original view.')
-        self.btn_home.clicked.connect(self.home)
-
         self.btn_fit_waterlevels = QToolButtonNormal('expand_all')
         self.btn_fit_waterlevels.setToolTip(
             "<p>Best fit the water level data along the x and y axis.</p>")
@@ -533,19 +529,6 @@ class WLCalc(QWidget, SaveFileMixin):
         """Clear the selecte water level data."""
         self.wl_selected_i = []
         self.draw_select_wl(draw)
-
-    def home(self):
-        """Reset the orgininal view of the figure."""
-        self._navig_toolbar.home()
-        if self.dformat == 0:
-            ax0 = self.fig.axes[0]
-            xfmt = mpl.ticker.ScalarFormatter()
-            ax0.xaxis.set_major_formatter(xfmt)
-            ax0.get_xaxis().get_major_formatter().set_useOffset(False)
-
-            xlim = ax0.get_xlim()
-            ax0.set_xlim(xlim[0] - self.dt4xls2mpl, xlim[1] - self.dt4xls2mpl)
-        self.setup_ax_margins()
 
     # ---- Water level edit tools
     def delete_selected_wl(self):

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -583,6 +583,32 @@ class WLCalc(QWidget, SaveFileMixin):
         self.setup_xticklabels_format()
         self.draw()
 
+    def zoom_axis(self, which: str, how: str):
+        """
+        Zoom in or out the specified axis.
+
+        Parameters
+        ----------
+        which : str
+            The axis to zoom in or out. Valid values are 'x' or 'y'.
+        how : str
+            Whether to zoom in or zoom out. Valid values are 'out' or 'in'.
+        """
+        ax = self.fig.axes[0]
+        if which == 'x':
+            xmin, xmax = ax.get_xlim()
+            xoffset = 0.1 * abs(xmax - xmin)
+            if how == 'in':
+                xoffset *= -1
+            ax.set_xlim(xmin=xmin - xoffset, xmax=xmax + xoffset)
+        elif which == 'y':
+            ymin, ymax = ax.get_ylim()
+            yoffset = 0.025 * abs(ymax - ymin)
+            if how == 'in':
+                yoffset *= -1
+            ax.set_ylim(ymin=ymin - yoffset, ymax=ymax + yoffset)
+        self.draw()
+
     def setup_axis_range(self, event=None):
         """Setup the range of the x- and y-axis."""
         if self.wldset is not None:

--- a/gwhat/tests/test_hydrocalc.py
+++ b/gwhat/tests/test_hydrocalc.py
@@ -182,5 +182,174 @@ def test_calc_mrc(hydrocalc, tmp_path, qtbot, mocker):
     assert qfdialog_patcher.call_count == 1
 
 
+def test_pan_axes(hydrocalc, tmp_path, qtbot, mocker):
+    """
+    Test that the tool to pan the axes with keyboard shortcuts is working
+    as expected.
+    """
+    fig = hydrocalc.canvas.figure
+
+    expected_xmin = 15655.9
+    expected_xmax = 16032.1
+
+    expected_ymin = 3.8955
+    expected_ymax = 2.7344
+
+    xoffset = (16032.1 - 15655.9) * 0.1
+    yoffset = (3.90 - 2.73) * 0.025
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == expected_xmin
+    assert round(xmax, 1) == expected_xmax
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 4) == expected_ymin
+    assert round(ymax, 4) == expected_ymax
+
+    # Pan xaxis to the left.
+    qtbot.keyPress(hydrocalc, Qt.Key_Left, modifier=Qt.ControlModifier)
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == round(expected_xmin + xoffset, 1)
+    assert round(xmax, 1) == round(expected_xmax + xoffset, 1)
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 4) == expected_ymin
+    assert round(ymax, 4) == expected_ymax
+
+    # Pan xaxis to the right (x2).
+    qtbot.keyPress(hydrocalc, Qt.Key_Right, modifier=Qt.ControlModifier)
+    qtbot.keyPress(hydrocalc, Qt.Key_Right, modifier=Qt.ControlModifier)
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == round(expected_xmin - xoffset, 1)
+    assert round(xmax, 1) == round(expected_xmax - xoffset, 1)
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 4) == expected_ymin
+    assert round(ymax, 4) == expected_ymax
+
+    # Pan yaxis up.
+    qtbot.keyPress(hydrocalc, Qt.Key_Up, modifier=Qt.ControlModifier)
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == round(expected_xmin - xoffset, 1)
+    assert round(xmax, 1) == round(expected_xmax - xoffset, 1)
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 2) == round(expected_ymin + yoffset, 2)
+    assert round(ymax, 2) == round(expected_ymax + yoffset, 2)
+
+    # Pan yaxis down.
+    qtbot.keyPress(hydrocalc, Qt.Key_Down, modifier=Qt.ControlModifier)
+    qtbot.keyPress(hydrocalc, Qt.Key_Down, modifier=Qt.ControlModifier)
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == round(expected_xmin - xoffset, 1)
+    assert round(xmax, 1) == round(expected_xmax - xoffset, 1)
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 2) == round(expected_ymin - yoffset, 2)
+    assert round(ymax, 2) == round(expected_ymax - yoffset, 2)
+
+
+def test_zoom_in_axes(hydrocalc, tmp_path, qtbot, mocker):
+    """
+    Test that the tool to zoom the axes in with keyboard shortcuts is
+    working as expected.
+    """
+    fig = hydrocalc.canvas.figure
+
+    expected_xmin = 15655.9
+    expected_xmax = 16032.1
+
+    expected_ymin = 3.8955
+    expected_ymax = 2.7344
+
+    xoffset = (16032.1 - 15655.9) * 0.1
+    yoffset = (3.90 - 2.73) * 0.025
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == expected_xmin
+    assert round(xmax, 1) == expected_xmax
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 4) == expected_ymin
+    assert round(ymax, 4) == expected_ymax
+
+    # Zoom xaxis in.
+    qtbot.keyPress(hydrocalc, Qt.Key_Right,
+                   modifier=Qt.ControlModifier | Qt.ShiftModifier)
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == round(expected_xmin + xoffset, 1)
+    assert round(xmax, 1) == round(expected_xmax - xoffset, 1)
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 4) == expected_ymin
+    assert round(ymax, 4) == expected_ymax
+
+    # Zoom yaxis in.
+    qtbot.keyPress(hydrocalc, Qt.Key_Up,
+                   modifier=Qt.ControlModifier | Qt.ShiftModifier)
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == round(expected_xmin + xoffset, 1)
+    assert round(xmax, 1) == round(expected_xmax - xoffset, 1)
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 2) == round(expected_ymin - yoffset, 2)
+    assert round(ymax, 2) == round(expected_ymax + yoffset, 2)
+
+
+def test_zoom_out_axes(hydrocalc, tmp_path, qtbot, mocker):
+    """
+    Test that the tool to zoom the axes out with keyboard shortcuts is
+    working as expected.
+    """
+    fig = hydrocalc.canvas.figure
+
+    expected_xmin = 15655.9
+    expected_xmax = 16032.1
+
+    expected_ymin = 3.8955
+    expected_ymax = 2.7344
+
+    xoffset = (16032.1 - 15655.9) * 0.1
+    yoffset = (3.90 - 2.73) * 0.025
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == expected_xmin
+    assert round(xmax, 1) == expected_xmax
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 4) == expected_ymin
+    assert round(ymax, 4) == expected_ymax
+
+    # Zoom xaxis out.
+    qtbot.keyPress(hydrocalc, Qt.Key_Left,
+                   modifier=Qt.ControlModifier | Qt.ShiftModifier)
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == round(expected_xmin - xoffset, 1)
+    assert round(xmax, 1) == round(expected_xmax + xoffset, 1)
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 4) == expected_ymin
+    assert round(ymax, 4) == expected_ymax
+
+    # Zoom yaxis in.
+    qtbot.keyPress(hydrocalc, Qt.Key_Down,
+                   modifier=Qt.ControlModifier | Qt.ShiftModifier)
+
+    xmin, xmax = fig.axes[0].get_xlim()
+    assert round(xmin, 1) == round(expected_xmin - xoffset, 1)
+    assert round(xmax, 1) == round(expected_xmax + xoffset, 1)
+
+    ymin, ymax = fig.axes[0].get_ylim()
+    assert round(ymin, 2) == round(expected_ymin + yoffset, 2)
+    assert round(ymax, 2) == round(expected_ymax - yoffset, 2)
+
+
 if __name__ == "__main__":
     pytest.main(['-x', __file__, '-v', '-rw'])

--- a/gwhat/utils/icons.py
+++ b/gwhat/utils/icons.py
@@ -81,17 +81,17 @@ RED = '#aa0000'
 
 FA_ICONS = {
     'arrow_left': [
-        ('mdi.arrow-left-bold',),
-        {'color': COLOR, 'scale_factor': 1.3}],
+        ('mdi.arrow-left-thick',),
+        {'color': COLOR, 'scale_factor': 1.2}],
     'arrow_right': [
-        ('mdi.arrow-right-bold',),
-        {'color': COLOR, 'scale_factor': 1.3}],
+        ('mdi.arrow-right-thick',),
+        {'color': COLOR, 'scale_factor': 1.2}],
     'arrow_up': [
-        ('mdi.arrow-up-bold',),
-        {'color': COLOR, 'scale_factor': 1.3}],
+        ('mdi.arrow-up-thick',),
+        {'color': COLOR, 'scale_factor': 1.2}],
     'arrow_down': [
-        ('mdi.arrow-down-bold',),
-        {'color': COLOR, 'scale_factor': 1.3}],
+        ('mdi.arrow-down-thick',),
+        {'color': COLOR, 'scale_factor': 1.2}],
     'calendar': [
         ('mdi.calendar-question',),
         {'color': COLOR, 'scale_factor': 1.3}],

--- a/gwhat/utils/icons.py
+++ b/gwhat/utils/icons.py
@@ -80,6 +80,18 @@ GREEN = '#00aa00'
 RED = '#aa0000'
 
 FA_ICONS = {
+    'arrow_left': [
+        ('mdi.arrow-left-bold',),
+        {'color': COLOR, 'scale_factor': 1.3}],
+    'arrow_right': [
+        ('mdi.arrow-right-bold',),
+        {'color': COLOR, 'scale_factor': 1.3}],
+    'arrow_up': [
+        ('mdi.arrow-up-bold',),
+        {'color': COLOR, 'scale_factor': 1.3}],
+    'arrow_down': [
+        ('mdi.arrow-down-bold',),
+        {'color': COLOR, 'scale_factor': 1.3}],
     'calendar': [
         ('mdi.calendar-question',),
         {'color': COLOR, 'scale_factor': 1.3}],


### PR DESCRIPTION
When picking stuff in the viewer (e.g. recessions), zooming and panning the axes is a pain because you have to click on the `Pan and Zoom` button to activate the navigation mode, then zoom and/or pan the axes with the mouse, and finally click back on the tool to continue picking.

This PR add buttons and shortcuts to conveniently pan and zoom the x- and y-axis with the keyboard. The new shortcuts are meant to mimic the functionalities of the pan and zoom navigation mode :

- Ctrl + Left : Move the x-axis to the left
- Ctrl + Right: Move the x-axis to the right
- Ctrl + Up : Move the y-axis up
- Ctrl + Down : Move the y-axis down

And also :

- Ctrl + Shift + Left : Zoom in on the x-axis
- Ctrl + Shift + Right: Zoom out on the x-axis
- Ctrl + Shift + Up : Zoom in on the y-axis
- Ctrl + Shift + Down : Zoom out on the y-axis

Also, this PR remove the `Home` button, because it does exactly the same thing as the `Best Fit` button.

![demo_gwhat_navig_zoom_axis](https://user-images.githubusercontent.com/10170372/214928600-bee21ef9-f8bd-44e0-942a-46dfda1ea770.gif)
