### PR TITLE
PR: Disable hydrocalc toolbar context menu and remove the alpha on the precip plot

### DIFF
--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -397,6 +397,7 @@ class WLCalc(QWidget, SaveFileMixin):
     def __initUI__(self):
         # Setup the left widget.
         left_widget = QMainWindow()
+        left_widget.setContextMenuPolicy(Qt.NoContextMenu)
 
         self.toolbar = self._setup_toolbar()
         self.toolbar.setStyleSheet("QToolBar {border: 0px; spacing:1px;}")

--- a/gwhat/HydroCalc2.py
+++ b/gwhat/HydroCalc2.py
@@ -897,10 +897,10 @@ class WLCalc(QWidget, SaveFileMixin):
 
             self.h_rain = ax.fill_between(
                 time_bar, 0, rain_bar, color=[23/255, 52/255, 88/255],
-                zorder=100, linestyle='None', alpha=0.65, lw=0)
+                zorder=100, linestyle='None', lw=0)
             self.h_ptot = ax.fill_between(
-                time_bar, 0, ptot_bar, color=[165/255, 165/255, 165/255],
-                zorder=50, linestyle='None', alpha=0.65, lw=0)
+                time_bar, 0, ptot_bar, color='0.65',
+                zorder=50, linestyle='None', lw=0)
             self.h_etp.set_data(time_bin, etp_bin)
         self.setup_ax_margins()
 


### PR DESCRIPTION
- Disabled hydrocalc toolbar context menu, so that one cannot close the toolbar by mistake
- Removed the alpha on the snow and rain `fill_between` plots. I don't know why I added an alpha there, but it is not needed and probably have a negative impact on the plotting performance.